### PR TITLE
fix: publicise state property

### DIFF
--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -8,7 +8,7 @@ public final class AppAuthSession: LoginSession {
     private var flow: OIDExternalUserAgentSession?
     private(set) var authorizationCode: String?
     private var error: Error?
-    private(set) var state: String?
+    public private(set) var state: String?
     private(set) var stateReponse: String?
     
     private let service: TokenServicing

--- a/Sources/Authentication/Custom/CustomAuthSession.swift
+++ b/Sources/Authentication/Custom/CustomAuthSession.swift
@@ -9,7 +9,7 @@ enum LoginError: Error {
 public final class CustomAuthSession: NSObject, LoginSession {
     private let context: UIWindow
     private var session: ASWebAuthenticationSession?
-    private(set) var state: String?
+    public private(set) var state: String?
     private let nonce: String
     
     private let service: TokenServicing

--- a/Sources/Authentication/LoginSession.swift
+++ b/Sources/Authentication/LoginSession.swift
@@ -2,6 +2,7 @@ import UIKit
 
 public protocol LoginSession {
     init(window: UIWindow)
+    var state: String? { get }
     func present(configuration: LoginSessionConfiguration)
     func finalise(callback: URL) async throws -> TokenResponse
     func cancel()


### PR DESCRIPTION
# iOS | Receive Auth Code and State from deeplink

This PR publicises the `state` parameter of a Type conforming to `LoginSession`. This is in order for us to compare the value which was passed as part of the call to authenticate to that value which comes back from the redirect URI.

# Checklist

## Before raising your pull request:
- [x] Update the documentation to reflect your changes
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
