### PR TITLE
fix: updating networking package repo to new repo

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -10,12 +10,12 @@
       }
     },
     {
-      "identity" : "di-mobile-ios-networking",
+      "identity" : "mobile-ios-networking",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/alphagov/di-mobile-ios-networking",
+      "location" : "https://github.com/govuk-one-login/mobile-ios-networking.git",
       "state" : {
         "branch" : "main",
-        "revision" : "d248dca8944e0d61be3c0e27060ca9b0cdef023b"
+        "revision" : "8724c7ffcbc2546e3b1fa57f1021769e12b475ea"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -14,25 +14,25 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/openid/AppAuth-iOS.git",
                  branch: "master"),
-        .package(url: "https://github.com/alphagov/di-mobile-ios-networking",
+        .package(url: "https://github.com/govuk-one-login/mobile-ios-networking.git",
                 branch: "main")
     ],
     targets: [
         .target(name: "Authentication",
                 dependencies: [
                     .product(name: "AppAuth", package: "AppAuth-iOS"),
-                    .product(name: "Networking", package: "di-mobile-ios-networking")
+                    .product(name: "Networking", package: "mobile-ios-networking")
                 ]),
         .testTarget(name: "AuthenticationTests",
                     dependencies: [
                         "Authentication",
                         "UserDetails",
-                        .product(name: "MockNetworking", package: "di-mobile-ios-networking")
+                        .product(name: "MockNetworking", package: "mobile-ios-networking")
                     ]),
         
         .target(name: "UserDetails",
                dependencies: [
-                .product(name: "Networking", package: "di-mobile-ios-networking")
+                .product(name: "Networking", package: "mobile-ios-networking")
                ])
     ]
 )


### PR DESCRIPTION
# Updating the package manifest for `Networking` package

This PR updates the manifest to point to the new repo for `Networking`. Currently the package points to the old repo location which causes package resolution errors when importing into an app that also imports `Networking` from the new location.

# Checklist

## Before raising your pull request:
~- [ ] Update the documentation to reflect your changes~
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
~- [ ] Written Unit and Integration tests if needed~

~- [ ] Met all accessibility requirements?~
    ~- [ ] Checked dynamic type sizes are applied~
    ~- [ ] Checked VoiceOver can navigate your new code~
    ~- [ ] Checked a user can navigate only using a keyboard around your new code~ 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
