### PR TITLE
feat: expose LoginError to package consumers

### DIFF
--- a/Sources/Authentication/LoginError.swift
+++ b/Sources/Authentication/LoginError.swift
@@ -1,3 +1,3 @@
-enum LoginError: Error {
+public enum LoginError: Error {
     case generic(description: String)
 }


### PR DESCRIPTION
# feat: expose LoginError to package consumers

The `LoginError` is unavailable outside of the package due to an internal protection level. This PR makes the error public for consumers of the package to catch.

# Checklist

## Before raising your pull request:
~- [ ] Update the documentation to reflect your changes~
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
~- [ ] Written Unit and Integration tests if needed~

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
