### PR TITLE
fix: handle errors from login flow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -29,6 +29,10 @@ jobs:
         run: |
           swiftlint --strict
           
+      - name: Xcode select
+        run: |
+          sudo xcode-select -s /Applications/Xcode_15.1.app
+          
       - name: Build and Test
         run: |
           xcodebuild -scheme Authentication-Package test \

--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -19,6 +19,10 @@ jobs:
         with:
           lfs: 'true'
           
+      - name: Xcode select
+        run: |
+          sudo xcode-select -s /Applications/Xcode_15.1.app
+          
       - name: Build and Test
         run: |
           xcodebuild -scheme Authentication-Package test \

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .package(url: "https://github.com/openid/AppAuth-iOS.git",
                  branch: "master"),
         .package(url: "https://github.com/govuk-one-login/mobile-ios-networking.git",
-                branch: "main")
+                 branch: "main")
     ],
     targets: [
         .target(name: "Authentication",
@@ -25,14 +25,17 @@ let package = Package(
                 ]),
         .testTarget(name: "AuthenticationTests",
                     dependencies: [
-                        "Authentication",
-                        "UserDetails",
-                        .product(name: "MockNetworking", package: "mobile-ios-networking")
+                        "Authentication"
                     ]),
         
         .target(name: "UserDetails",
-               dependencies: [
-                .product(name: "Networking", package: "mobile-ios-networking")
-               ])
+                dependencies: [
+                    .product(name: "Networking", package: "mobile-ios-networking")
+                ]),
+        .testTarget(name: "UserDetailsTests",
+                    dependencies: [
+                        "UserDetails",
+                        .product(name: "MockNetworking", package: "mobile-ios-networking")
+                    ])
     ]
 )

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ The struct also contains three enums to handle the language, the response and th
 
 A class to handle the login flow with the given auth provider and conforms to the `LoginSession` protocol. It uses the `UIWindow` to know where to display the login modal.
 
-`present` takes configuration, which comes from `LoginSessionConfiguration`, as a parameter and contains the login information to make the request. 
+`performLoginFlow` takes configuration, which comes from `LoginSessionConfiguration`, as a parameter and contains the login information to make the request. Any errors received in the authorization flow through the openID package are thrown. Otherwise, the token response is returned.
 
-`finalise` takes a URL to redirect to as a parameter and returns a token response. If `userAgent` was not assigned inside the `present` method an error is thrown. Otherwise, the token response is returned. 
+`finalise` takes a URL to redirect to as a parameter and returns a token response. If `userAgent` was not assigned inside the `present` method an error is thrown.
 
 ## Example Implementation
 
@@ -107,11 +107,11 @@ let configuration = LoginSessionConfiguration(authorizationEndpoint: url,
                                               vectorsOfTrust: "someVectorOfTrust",
                                               locale: .en)
                                               
-session.present(configuration: configuration)
+session.performLoginFlow(configuration: configuration)
 
 ```
 
-Your code should include a redirect URL handler method in either the SceneDelegate or AppDelegate. Therefore, once `present` has been called, the user logs in and selects a redirect link on the login modal. The device will redirect into the app and the url is passed into the call to `finalise`.
+Your code should include a redirect URL handler method in either the SceneDelegate or AppDelegate. Therefore, once `performLoginFlow` has been called, the user logs in and selects a redirect link on the login modal. The device will redirect into the app and the url is passed into the call to `finalise`.
 
 ```swift
 // SceneDelegate.swift

--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -55,8 +55,6 @@ public final class AppAuthSession: LoginSession {
                 self.handleResponse(authState: authState, error: error)
             }
         }
-        continuation = nil
-        userAgent = nil
     }
     
     /// Ensures `finalise` is public and can be called by the app

--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -54,6 +54,7 @@ public final class AppAuthSession: LoginSession {
                                           prefersEphemeralSession: configuration.prefersEphemeralWebSession) { authState, error in
                 self.handleResponse(authState: authState, error: error)
             }
+            self.continuation = nil
         }
         self.userAgent = nil
     }

--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -15,7 +15,7 @@ public final class AppAuthSession: LoginSession {
         self.window = window
     }
     
-    /// Ensures `present` is public and can be called by the app
+    /// Ensures `performLoginFlow` is public and can be called by the app
     /// Presents the login modal
     ///
     /// - Parameters:
@@ -56,11 +56,10 @@ public final class AppAuthSession: LoginSession {
                 do {
                     let response = try self.handleResponse(authState: authState, error: error)
                     continuation.resume(returning: response)
-                    self.userAgent = nil
                 } catch {
                     continuation.resume(throwing: error)
-                    self.userAgent = nil
                 }
+                self.userAgent = nil
             }
         }
     }

--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -27,7 +27,7 @@ public final class AppAuthSession: LoginSession {
     
     /// This is here for testing and allows `service` to be mocked
     @MainActor
-    func performLoginFlow(configuration: LoginSessionConfiguration, service: OIDAuthState.Type = OIDAuthState.self) async throws -> TokenResponse {
+    func performLoginFlow(configuration: LoginSessionConfiguration, service: OIDAuthState.Type) async throws -> TokenResponse {
         guard let viewController = window.rootViewController else {
             fatalError("empty vc in window, please add vc")
         }

--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -54,6 +54,7 @@ public final class AppAuthSession: LoginSession {
                                           prefersEphemeralSession: configuration.prefersEphemeralWebSession) { authState, error in
                 self.handleResponse(authState: authState, error: error)
             }
+            self.userAgent = nil
         }
     }
     

--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -54,8 +54,8 @@ public final class AppAuthSession: LoginSession {
                                           prefersEphemeralSession: configuration.prefersEphemeralWebSession) { authState, error in
                 self.handleResponse(authState: authState, error: error)
             }
-            self.userAgent = nil
         }
+        self.userAgent = nil
     }
     
     /// Ensures `finalise` is public and can be called by the app

--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -5,7 +5,9 @@ import AppAuth
 public final class AppAuthSession: LoginSession {
     private let window: UIWindow
     private var userAgent: OIDExternalUserAgentSession?
-    private var continuation: CheckedContinuation<TokenResponse, Error>?
+    var isActive: Bool {
+        userAgent != nil
+    }
     
     /// - Parameters:
     ///    - window: UIWindow with a root view controller where you wish to show the login dialog
@@ -19,13 +21,13 @@ public final class AppAuthSession: LoginSession {
     /// - Parameters:
     ///     - configuration: object that contains your LoginSessionConfiguration
     @MainActor
-    public func present(configuration: LoginSessionConfiguration) async throws {
-        try await present(configuration: configuration, service: OIDAuthState.self)
+    public func performLoginFlow(configuration: LoginSessionConfiguration) async throws -> TokenResponse {
+        try await performLoginFlow(configuration: configuration, service: OIDAuthState.self)
     }
     
     /// This is here for testing and allows `service` to be mocked
     @MainActor
-    func present(configuration: LoginSessionConfiguration, service: OIDAuthState.Type = OIDAuthState.self) async throws {
+    func performLoginFlow(configuration: LoginSessionConfiguration, service: OIDAuthState.Type = OIDAuthState.self) async throws -> TokenResponse {
         guard let viewController = window.rootViewController else {
             fatalError("empty vc in window, please add vc")
         }
@@ -47,13 +49,16 @@ public final class AppAuthSession: LoginSession {
             ]
         )
         
-        _ = try await withCheckedThrowingContinuation { continuation in
-            self.continuation = continuation
+        return try await withCheckedThrowingContinuation { continuation in
             userAgent = service.authState(byPresenting: request,
                                           presenting: viewController,
                                           prefersEphemeralSession: configuration.prefersEphemeralWebSession) { authState, error in
-                self.handleResponse(authState: authState, error: error)
-                self.continuation = nil
+                do {
+                    let response = try self.handleResponse(authState: authState, error: error)
+                    continuation.resume(returning: response)
+                } catch {
+                    continuation.resume(throwing: error)
+                }
             }
         }
     }
@@ -64,27 +69,20 @@ public final class AppAuthSession: LoginSession {
     /// - Parameter url: redirect URL from login modal
     /// - Returns: TokenResponse, tokens for the session
     @MainActor
-    public func finalise(redirectURL url: URL) async throws -> TokenResponse {
+    public func finalise(redirectURL url: URL) throws {
         guard let userAgent else {
             throw LoginError.generic(description: "User Agent Session does not exist")
         }
-        return try await withCheckedThrowingContinuation { continuation in
-            self.continuation = continuation
-            userAgent.resumeExternalUserAgentFlow(with: url)
-            self.userAgent = nil
-        }
+        userAgent.resumeExternalUserAgentFlow(with: url)
+        self.userAgent = nil
     }
     
-    private func handleResponse(authState: OIDAuthState?, error: Error?) {
-        do {
-            try checkNoError(error)
-            let authState = try checkAuthState(authState)
-            let token = try extractToken(authState: authState)
-            let tokenResponse = try generateTokenResponse(token: token, authState: authState)
-            continuation?.resume(returning: tokenResponse)
-        } catch {
-            continuation?.resume(throwing: error)
-        }
+    private func handleResponse(authState: OIDAuthState?, error: Error?) throws -> TokenResponse {
+        try checkNoError(error)
+        let authState = try checkAuthState(authState)
+        let token = try extractToken(authState: authState)
+        let tokenResponse = try generateTokenResponse(token: token, authState: authState)
+        return tokenResponse
     }
     
     private func checkNoError(_ error: Error?) throws {

--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -53,6 +53,7 @@ public final class AppAuthSession: LoginSession {
                                           presenting: viewController,
                                           prefersEphemeralSession: configuration.prefersEphemeralWebSession) { authState, error in
                 self.handleResponse(authState: authState, error: error)
+                self.continuation = nil
             }
         }
     }

--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -54,9 +54,9 @@ public final class AppAuthSession: LoginSession {
                                           prefersEphemeralSession: configuration.prefersEphemeralWebSession) { authState, error in
                 self.handleResponse(authState: authState, error: error)
             }
-            self.continuation = nil
         }
-        self.userAgent = nil
+        continuation = nil
+        userAgent = nil
     }
     
     /// Ensures `finalise` is public and can be called by the app

--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -19,13 +19,13 @@ public final class AppAuthSession: LoginSession {
     /// - Parameters:
     ///     - configuration: object that contains your LoginSessionConfiguration
     @MainActor
-    public func present(configuration: LoginSessionConfiguration) {
-        present(configuration: configuration, service: OIDAuthState.self)
+    public func present(configuration: LoginSessionConfiguration) throws {
+        try present(configuration: configuration, service: OIDAuthState.self)
     }
     
     /// This is here for testing and allows `service` to be mocked
     @MainActor
-    func present(configuration: LoginSessionConfiguration, service: OIDAuthState.Type = OIDAuthState.self) {
+    func present(configuration: LoginSessionConfiguration, service: OIDAuthState.Type = OIDAuthState.self) throws {
         guard let viewController = window.rootViewController else {
             fatalError("empty vc in window, please add vc")
         }

--- a/Sources/Authentication/LoginSession.swift
+++ b/Sources/Authentication/LoginSession.swift
@@ -2,6 +2,6 @@ import UIKit
 
 public protocol LoginSession {
     init(window: UIWindow)
-    func present(configuration: LoginSessionConfiguration)
+    func present(configuration: LoginSessionConfiguration) throws
     func finalise(redirectURL url: URL) async throws -> TokenResponse
 }

--- a/Sources/Authentication/LoginSession.swift
+++ b/Sources/Authentication/LoginSession.swift
@@ -2,6 +2,6 @@ import UIKit
 
 public protocol LoginSession {
     init(window: UIWindow)
-    func present(configuration: LoginSessionConfiguration) async throws
-    func finalise(redirectURL url: URL) async throws -> TokenResponse
+    func performLoginFlow(configuration: LoginSessionConfiguration) async throws -> TokenResponse
+    func finalise(redirectURL url: URL) throws
 }

--- a/Sources/Authentication/LoginSession.swift
+++ b/Sources/Authentication/LoginSession.swift
@@ -2,6 +2,6 @@ import UIKit
 
 public protocol LoginSession {
     init(window: UIWindow)
-    func present(configuration: LoginSessionConfiguration) throws
+    func present(configuration: LoginSessionConfiguration) async throws
     func finalise(redirectURL url: URL) async throws -> TokenResponse
 }

--- a/Tests/AuthenticationTests/AppAuthSessionTests.swift
+++ b/Tests/AuthenticationTests/AppAuthSessionTests.swift
@@ -53,42 +53,60 @@ extension AppAuthSessionTests {
     }
     
     @MainActor
-    func test_finaliseAuthService_rejectsWhenNoAuthState() async throws {
+    func test_finaliseAuthService_rejectsWhenNoAuthState() throws {
+        let exp = expectation(description: "wait for token response")
         Task {
-            try await sut.performLoginFlow(configuration: .mock)
+            do {
+                _ = try await sut.performLoginFlow(configuration: .mock, service: MockOIDAuthState_NothingReturned.self)
+            } catch LoginError.generic(let description) {
+                XCTAssertTrue(description == "No authState")
+                exp.fulfill()
+            }
         }
         
-        do {
-            try sut.finalise(redirectURL: URL(string: "https://www.google.com")!)
-        } catch LoginError.generic(let description) {
-            XCTAssertTrue(description == "No authState")
-        }
+        waitForTruth(self.sut.isActive, timeout: 2)
+        
+        try sut.finalise(redirectURL: URL(string: "https://www.google.com")!)
+        
+        wait(for: [exp], timeout: 2)
     }
     
     @MainActor
-    func test_finaliseAuthService_rejectsWhenAuthStateMissingToken() async throws {
+    func test_finaliseAuthService_rejectsWhenAuthStateMissingToken() throws {
+        let exp = expectation(description: "wait for token response")
         Task {
-            try await sut.performLoginFlow(configuration: .mock)
+            do {
+                _ = try await sut.performLoginFlow(configuration: .mock, service: MockOIDAuthState_MissingAuthStateToken.self)
+            } catch LoginError.generic(let description) {
+                XCTAssertTrue(description == "Missing authState Token Response")
+                exp.fulfill()
+            }
         }
         
-        do {
-            try sut.finalise(redirectURL: URL(string: "https://www.google.com")!)
-        } catch LoginError.generic(let description) {
-            XCTAssertTrue(description == "Missing authState Token Response")
-        }
+        waitForTruth(self.sut.isActive, timeout: 2)
+        
+        try sut.finalise(redirectURL: URL(string: "https://www.google.com")!)
+        
+        wait(for: [exp], timeout: 2)
     }
     
     @MainActor
-    func test_finaliseAuthService_rejectsWhenAuthStateMissingProperty() async throws {
+    func test_finaliseAuthService_rejectsWhenAuthStateMissingProperty() throws {
+        let exp = expectation(description: "wait for token response")
         Task {
-            try await sut.performLoginFlow(configuration: .mock)
+            do {
+                _ = try await sut.performLoginFlow(configuration: .mock, service: MockOIDAuthState_MissingAuthStateProperty.self)
+            } catch LoginError.generic(let description) {
+                XCTAssertTrue(description == "Missing authState property")
+                exp.fulfill()
+            }
         }
         
-        do {
-            try sut.finalise(redirectURL: URL(string: "https://www.google.com")!)
-        } catch LoginError.generic(let description) {
-            XCTAssertTrue(description == "Missing authState property")
-        }
+        waitForTruth(self.sut.isActive, timeout: 2)
+        
+        try sut.finalise(redirectURL: URL(string: "https://www.google.com")!)
+        
+        wait(for: [exp], timeout: 2)
     }
 }
 

--- a/Tests/AuthenticationTests/AppAuthSessionTests.swift
+++ b/Tests/AuthenticationTests/AppAuthSessionTests.swift
@@ -47,7 +47,7 @@ extension AppAuthSessionTests {
         
         try sut.finalise(redirectURL: URL(string: "https://www.google.com?code=\(UUID().uuidString)&state=\(UUID().uuidString)")!)
         
-        wait(for: [exp], timeout: 2)
+        wait(for: [exp], timeout: 10)
     }
     
     @MainActor

--- a/Tests/AuthenticationTests/AppAuthSessionTests.swift
+++ b/Tests/AuthenticationTests/AppAuthSessionTests.swift
@@ -32,7 +32,7 @@ extension AppAuthSessionTests {
     }
     
     @MainActor
-    func test_finaliseAuthService_rejectsIncorrectStateParameter() throws {
+    func test_authService_rejectsIncorrectStateParameter() throws {
         let exp = expectation(description: "wait for token response")
         Task {
             do {
@@ -45,15 +45,13 @@ extension AppAuthSessionTests {
         
         waitForTruth(self.sut.isActive, timeout: 2)
         
-        let code = UUID().uuidString
-        let randomState = UUID().uuidString
-        try sut.finalise(redirectURL: URL(string: "https://www.google.com?code=\(code)&state=\(randomState)")!)
+        try sut.finalise(redirectURL: URL(string: "https://www.google.com?code=\(UUID().uuidString)&state=\(UUID().uuidString)")!)
         
         wait(for: [exp], timeout: 2)
     }
     
     @MainActor
-    func test_finaliseAuthService_rejectsWhenNoAuthState() throws {
+    func test_authService_rejectsWhenNoAuthState() throws {
         let exp = expectation(description: "wait for token response")
         Task {
             do {
@@ -72,7 +70,7 @@ extension AppAuthSessionTests {
     }
     
     @MainActor
-    func test_finaliseAuthService_rejectsWhenAuthStateMissingToken() throws {
+    func test_authService_rejectsWhenAuthStateMissingToken() throws {
         let exp = expectation(description: "wait for token response")
         Task {
             do {
@@ -91,7 +89,7 @@ extension AppAuthSessionTests {
     }
     
     @MainActor
-    func test_finaliseAuthService_rejectsWhenAuthStateMissingProperty() throws {
+    func test_authService_rejectsWhenAuthStateMissingProperty() throws {
         let exp = expectation(description: "wait for token response")
         Task {
             do {

--- a/Tests/AuthenticationTests/AppAuthSessionTests.swift
+++ b/Tests/AuthenticationTests/AppAuthSessionTests.swift
@@ -36,6 +36,7 @@ extension AppAuthSessionTests {
         let exp = expectation(description: "wait for token response")
         Task {
             do {
+                print("Login task started")
                 _ = try await sut.performLoginFlow(configuration: .mock)
                 XCTFail("Expected state mismatch error, got success")
             } catch LoginError.generic(let description) {
@@ -47,7 +48,7 @@ extension AppAuthSessionTests {
             exp.fulfill()
         }
         
-        waitForTruth(self.sut.isActive, timeout: 2)
+        waitForTruth(self.sut.isActive, timeout: 20)
         
         try sut.finalise(redirectURL: URL(string: "https://www.google.com?code=\(UUID().uuidString)&state=\(UUID().uuidString)")!)
         

--- a/Tests/AuthenticationTests/AppAuthSessionTests.swift
+++ b/Tests/AuthenticationTests/AppAuthSessionTests.swift
@@ -37,10 +37,14 @@ extension AppAuthSessionTests {
         Task {
             do {
                 _ = try await sut.performLoginFlow(configuration: .mock)
+                XCTFail("Expected state mismatch error, got success")
             } catch LoginError.generic(let description) {
                 XCTAssertTrue(description.starts(with: "State mismatch"))
-                exp.fulfill()
+            } catch {
+                XCTFail("Expected state mismatch error, got \(error)")
             }
+            
+            exp.fulfill()
         }
         
         waitForTruth(self.sut.isActive, timeout: 2)

--- a/Tests/AuthenticationTests/AppAuthSessionTests.swift
+++ b/Tests/AuthenticationTests/AppAuthSessionTests.swift
@@ -50,7 +50,7 @@ extension AppAuthSessionTests {
             exp.fulfill()
         }
         
-        waitForTruth(self.sut.isActive, timeout: 5)
+        waitForTruth(self.sut.isActive, timeout: 10)
         
         try sut.finalise(redirectURL: URL(string: "https://www.google.com?code=\(UUID().uuidString)&state=\(UUID().uuidString)")!)
         

--- a/Tests/AuthenticationTests/AppAuthSessionTests.swift
+++ b/Tests/AuthenticationTests/AppAuthSessionTests.swift
@@ -33,7 +33,7 @@ extension AppAuthSessionTests {
     
     @MainActor
     func test_finaliseAuthService_rejectsIncorrectStateParameter() async throws {
-        sut.present(configuration: .mock)
+        try sut.present(configuration: .mock)
         
         let code = UUID().uuidString
         let randomState = UUID().uuidString
@@ -46,7 +46,7 @@ extension AppAuthSessionTests {
     
     @MainActor
     func test_finaliseAuthService_rejectsWhenNoAuthState() async throws {
-        sut.present(configuration: .mock, service: MockOIDAuthState_NothingReturned.self)
+        try sut.present(configuration: .mock, service: MockOIDAuthState_NothingReturned.self)
         
         do {
             _ = try await sut.finalise(redirectURL: URL(string: "https://www.google.com")!)
@@ -57,7 +57,7 @@ extension AppAuthSessionTests {
     
     @MainActor
     func test_finaliseAuthService_rejectsWhenAuthStateMissingToken() async throws {
-        sut.present(configuration: .mock, service: MockOIDAuthState_MissingAuthStateToken.self)
+        try sut.present(configuration: .mock, service: MockOIDAuthState_MissingAuthStateToken.self)
         
         do {
             _ = try await sut.finalise(redirectURL: URL(string: "https://www.google.com")!)
@@ -68,7 +68,7 @@ extension AppAuthSessionTests {
     
     @MainActor
     func test_finaliseAuthService_rejectsWhenAuthStateMissingProperty() async throws {
-        sut.present(configuration: .mock, service: MockOIDAuthState_MissingAuthStateProperty.self)
+        try sut.present(configuration: .mock, service: MockOIDAuthState_MissingAuthStateProperty.self)
         
         do {
             _ = try await sut.finalise(redirectURL: URL(string: "https://www.google.com")!)

--- a/Tests/AuthenticationTests/AppAuthSessionTests.swift
+++ b/Tests/AuthenticationTests/AppAuthSessionTests.swift
@@ -33,7 +33,7 @@ extension AppAuthSessionTests {
     
     @MainActor
     func test_finaliseAuthService_rejectsIncorrectStateParameter() async throws {
-        try sut.present(configuration: .mock)
+        try await sut.present(configuration: .mock)
         
         let code = UUID().uuidString
         let randomState = UUID().uuidString
@@ -46,7 +46,7 @@ extension AppAuthSessionTests {
     
     @MainActor
     func test_finaliseAuthService_rejectsWhenNoAuthState() async throws {
-        try sut.present(configuration: .mock, service: MockOIDAuthState_NothingReturned.self)
+        try await sut.present(configuration: .mock, service: MockOIDAuthState_NothingReturned.self)
         
         do {
             _ = try await sut.finalise(redirectURL: URL(string: "https://www.google.com")!)
@@ -57,7 +57,7 @@ extension AppAuthSessionTests {
     
     @MainActor
     func test_finaliseAuthService_rejectsWhenAuthStateMissingToken() async throws {
-        try sut.present(configuration: .mock, service: MockOIDAuthState_MissingAuthStateToken.self)
+        try await sut.present(configuration: .mock, service: MockOIDAuthState_MissingAuthStateToken.self)
         
         do {
             _ = try await sut.finalise(redirectURL: URL(string: "https://www.google.com")!)
@@ -68,7 +68,7 @@ extension AppAuthSessionTests {
     
     @MainActor
     func test_finaliseAuthService_rejectsWhenAuthStateMissingProperty() async throws {
-        try sut.present(configuration: .mock, service: MockOIDAuthState_MissingAuthStateProperty.self)
+        try await sut.present(configuration: .mock, service: MockOIDAuthState_MissingAuthStateProperty.self)
         
         do {
             _ = try await sut.finalise(redirectURL: URL(string: "https://www.google.com")!)

--- a/Tests/AuthenticationTests/LoginSessionConfigurationTests.swift
+++ b/Tests/AuthenticationTests/LoginSessionConfigurationTests.swift
@@ -7,6 +7,7 @@ final class LoginSessionConfigurationTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
+        
         sut = LoginSessionConfiguration(authorizationEndpoint: URL(string: "https://www.google.com")!,
                                         tokenEndpoint: URL(string: "https://www.google.com/token")!,
                                         responseType: .code,

--- a/Tests/AuthenticationTests/XCTestCase+Extensions.swift
+++ b/Tests/AuthenticationTests/XCTestCase+Extensions.swift
@@ -1,0 +1,12 @@
+import Foundation
+import XCTest
+
+extension XCTestCase {
+    func waitForTruth(_ expression: @autoclosure @escaping () -> Bool,
+                      timeout: TimeInterval) {
+        let exp = expectation(for: .init { _, _ in
+            expression()
+        }, evaluatedWith: nil, handler: nil)
+        wait(for: [exp], timeout: timeout)
+    }
+}


### PR DESCRIPTION
# DCMAW-7695: iOS | Handle One Login web authentication modal cancel error

A [commit](https://github.com/govuk-one-login/mobile-ios-authentication/pull/15) to amend the [iOS Authentication package](https://github.com/govuk-one-login/mobile-ios-authentication) returns any error received in the login flow in wrapping the [openID App Auth package](https://github.com/openid/AppAuth-iOS).

However, the package only catches errors when `finalise` has been called. 
Some errors received from the App Auth package, for instance the web authentication modal is cancelled, are passed into our authentication wrapper package’s API callback but not handled properly.

# Checklist

## Before raising your pull request:
- [x] Update the documentation to reflect your changes
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
