### PR TITLE
feat: transform AppAuth errors

### DIFF
--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -87,41 +87,25 @@ public final class AppAuthSession: LoginSession {
     }
     
     private func handleIfError(_ error: Error?) throws {
-        switch error {
-        case .some(let error as NSError):
-            switch error.domain {
-            case OIDGeneralErrorDomain:
-                switch error.code {
-                case -3:
-                    throw LoginError.userCancelled
-                case -5:
-                    throw LoginError.network
-                case -6:
-                    throw LoginError.non200
-                default:
-                    break
-                }
-            case OIDOAuthAuthorizationErrorDomain:
-                switch error.code {
-                case -2:
-                    throw LoginError.invalidRequest
-                case -61439:
-                    throw LoginError.clientError
-                default:
-                    break
-                }
-            case OIDOAuthTokenErrorDomain:
-                switch error.code {
-                case -2:
-                    throw LoginError.invalidRequest
-                default:
-                    break
-                }
-            default:
-                throw LoginError.generic(description: error.localizedDescription)
-            }
-        case .none:
-            break
+        guard let error = error as? NSError else {
+            return
+        }
+        
+        switch (error.domain, error.code) {
+        case (OIDGeneralErrorDomain, -3):
+            throw LoginError.userCancelled
+        case (OIDGeneralErrorDomain, -5):
+            throw LoginError.network
+        case (OIDGeneralErrorDomain, -6):
+            throw LoginError.non200
+        case (OIDOAuthAuthorizationErrorDomain, -2):
+            throw LoginError.invalidRequest
+        case (OIDOAuthAuthorizationErrorDomain, -61439):
+            throw LoginError.clientError
+        case (OIDOAuthTokenErrorDomain, -2):
+            throw LoginError.invalidRequest
+        default:
+            throw LoginError.generic(description: error.localizedDescription)
         }
     }
     

--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -110,6 +110,13 @@ public final class AppAuthSession: LoginSession {
                 default:
                     break
                 }
+            case OIDOAuthTokenErrorDomain:
+                switch error.code {
+                case -2:
+                    throw LoginError.invalidRequest
+                default:
+                    break
+                }
             default:
                 throw LoginError.generic(description: error.localizedDescription)
             }

--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -87,6 +87,8 @@ public final class AppAuthSession: LoginSession {
     
     private func handleIfError(_ error: Error?) throws {
         if let error {
+            print("Whole error description: \(error)")
+            print("Localised description: \(error.localizedDescription)")
             throw LoginError.generic(description: error.localizedDescription)
         }
     }

--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -98,12 +98,10 @@ public final class AppAuthSession: LoginSession {
             throw LoginError.network
         case (OIDGeneralErrorDomain, -6):
             throw LoginError.non200
-        case (OIDOAuthAuthorizationErrorDomain, -2):
+        case (OIDOAuthAuthorizationErrorDomain, -2), (OIDOAuthTokenErrorDomain, -2):
             throw LoginError.invalidRequest
         case (OIDOAuthAuthorizationErrorDomain, -61439):
             throw LoginError.clientError
-        case (OIDOAuthTokenErrorDomain, -2):
-            throw LoginError.invalidRequest
         default:
             throw LoginError.generic(description: error.localizedDescription)
         }

--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -72,6 +72,7 @@ public final class AppAuthSession: LoginSession {
     @MainActor
     public func finalise(redirectURL url: URL) throws {
         guard let userAgent else {
+            self.userAgent = nil
             throw LoginError.generic(description: "User Agent Session does not exist")
         }
         userAgent.resumeExternalUserAgentFlow(with: url)
@@ -95,6 +96,17 @@ public final class AppAuthSession: LoginSession {
                     throw LoginError.userCancelled
                 case -5:
                     throw LoginError.network
+                case -6:
+                    throw LoginError.non200
+                default:
+                    break
+                }
+            case OIDOAuthAuthorizationErrorDomain:
+                switch error.code {
+                case -2:
+                    throw LoginError.invalidRequest
+                case -61439:
+                    throw LoginError.clientError
                 default:
                     break
                 }

--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -86,12 +86,23 @@ public final class AppAuthSession: LoginSession {
     }
     
     private func handleIfError(_ error: Error?) throws {
-        if let error {
-            print("Whole error description: \(error)")
-            print("Localised description: \(error.localizedDescription)")
-            let errorCode = OIDErrorCode(rawValue: -5)
-            print(OIDErrorUtilities.error(with: errorCode!, underlyingError: nil, description: nil))
-            throw LoginError.generic(description: error.localizedDescription)
+        switch error {
+        case .some(let error as NSError):
+            switch error.domain {
+            case OIDGeneralErrorDomain:
+                switch error.code {
+                case -3:
+                    throw LoginError.userCancelled
+                case -5:
+                    throw LoginError.network
+                default:
+                    break
+                }
+            default:
+                throw LoginError.generic(description: error.localizedDescription)
+            }
+        case .none:
+            break
         }
     }
     

--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -89,6 +89,8 @@ public final class AppAuthSession: LoginSession {
         if let error {
             print("Whole error description: \(error)")
             print("Localised description: \(error.localizedDescription)")
+            let errorCode = OIDErrorCode(rawValue: -5)
+            print(OIDErrorUtilities.error(with: errorCode!, underlyingError: nil, description: nil))
             throw LoginError.generic(description: error.localizedDescription)
         }
     }

--- a/Sources/Authentication/LoginError.swift
+++ b/Sources/Authentication/LoginError.swift
@@ -1,3 +1,5 @@
 public enum LoginError: Error {
     case generic(description: String)
+    case userCancelled
+    case network
 }

--- a/Sources/Authentication/LoginError.swift
+++ b/Sources/Authentication/LoginError.swift
@@ -1,5 +1,8 @@
 public enum LoginError: Error {
+    case clientError
+    case invalidRequest
     case generic(description: String)
-    case userCancelled
     case network
+    case non200
+    case userCancelled
 }

--- a/Sources/Authentication/LoginError.swift
+++ b/Sources/Authentication/LoginError.swift
@@ -1,4 +1,4 @@
-public enum LoginError: Error {
+public enum LoginError: Error, Equatable {
     case clientError
     case generic(description: String)
     case invalidRequest

--- a/Sources/Authentication/LoginError.swift
+++ b/Sources/Authentication/LoginError.swift
@@ -1,7 +1,7 @@
 public enum LoginError: Error {
     case clientError
-    case invalidRequest
     case generic(description: String)
+    case invalidRequest
     case network
     case non200
     case userCancelled

--- a/Tests/AuthenticationTests/AppAuthSessionTests.swift
+++ b/Tests/AuthenticationTests/AppAuthSessionTests.swift
@@ -41,8 +41,8 @@ extension AppAuthSessionTests {
             do {
                 _ = try await sut.performLoginFlow(configuration: .mock)
                 XCTFail("Expected state mismatch error, got success")
-            } catch LoginError.clientError {
-                XCTAssertTrue(true)
+            } catch let error as LoginError {
+                XCTAssertEqual(error, .clientError)
             } catch {
                 XCTFail("Expected state mismatch error, got \(error)")
             }
@@ -64,8 +64,8 @@ extension AppAuthSessionTests {
             do {
                 _ = try await sut.performLoginFlow(configuration: .mock, service: MockOIDAuthState_UserCancelled.self)
                 XCTFail("Expected user cancelled error, got success")
-            } catch LoginError.userCancelled {
-                XCTAssertTrue(true)
+            } catch let error as LoginError {
+                XCTAssertEqual(error, .userCancelled)
             } catch {
                 XCTFail("Expected user cancelled error, got \(error)")
             }
@@ -87,8 +87,8 @@ extension AppAuthSessionTests {
             do {
                 _ = try await sut.performLoginFlow(configuration: .mock, service: MockOIDAuthState_NetworkError.self)
                 XCTFail("Expected network error, got success")
-            } catch LoginError.network {
-                XCTAssertTrue(true)
+            } catch let error as LoginError {
+                XCTAssertEqual(error, .network)
             } catch {
                 XCTFail("Expected network error, got \(error)")
             }
@@ -110,8 +110,8 @@ extension AppAuthSessionTests {
             do {
                 _ = try await sut.performLoginFlow(configuration: .mock, service: MockOIDAuthState_Non200.self)
                 XCTFail("Expected non 200 error, got success")
-            } catch LoginError.non200 {
-                XCTAssertTrue(true)
+            } catch let error as LoginError {
+                XCTAssertEqual(error, .non200)
             } catch {
                 XCTFail("Expected non 200 error, got \(error)")
             }
@@ -133,8 +133,8 @@ extension AppAuthSessionTests {
             do {
                 _ = try await sut.performLoginFlow(configuration: .mock, service: MockOIDAuthState_AuthorizationInvalidRequest.self)
                 XCTFail("Expected authorization invalid request error, got success")
-            } catch LoginError.invalidRequest {
-                XCTAssertTrue(true)
+            } catch let error as LoginError {
+                XCTAssertEqual(error, .invalidRequest)
             } catch {
                 XCTFail("Expected authorization invalid request error, got \(error)")
             }
@@ -156,8 +156,8 @@ extension AppAuthSessionTests {
             do {
                 _ = try await sut.performLoginFlow(configuration: .mock, service: MockOIDAuthState_ClientError.self)
                 XCTFail("Expected client error, got success")
-            } catch LoginError.clientError {
-                XCTAssertTrue(true)
+            } catch let error as LoginError {
+                XCTAssertEqual(error, .clientError)
             } catch {
                 XCTFail("Expected client error, got \(error)")
             }
@@ -179,8 +179,8 @@ extension AppAuthSessionTests {
             do {
                 _ = try await sut.performLoginFlow(configuration: .mock, service: MockOIDAuthState_TokenInvalidRequest.self)
                 XCTFail("Expected token invalid request error, got success")
-            } catch LoginError.invalidRequest {
-                XCTAssertTrue(true)
+            } catch let error as LoginError {
+                XCTAssertEqual(error, .invalidRequest)
             } catch {
                 XCTFail("Expected token invalid request error, got \(error)")
             }

--- a/Tests/AuthenticationTests/AppAuthSessionTests.swift
+++ b/Tests/AuthenticationTests/AppAuthSessionTests.swift
@@ -50,7 +50,7 @@ extension AppAuthSessionTests {
             exp.fulfill()
         }
         
-        waitForTruth(self.sut.isActive, timeout: 10)
+        waitForTruth(self.sut.isActive, timeout: 20)
         
         try sut.finalise(redirectURL: URL(string: "https://www.google.com?code=\(UUID().uuidString)&state=\(UUID().uuidString)")!)
         

--- a/Tests/AuthenticationTests/AppAuthSessionTests.swift
+++ b/Tests/AuthenticationTests/AppAuthSessionTests.swift
@@ -41,8 +41,8 @@ extension AppAuthSessionTests {
             do {
                 _ = try await sut.performLoginFlow(configuration: .mock)
                 XCTFail("Expected state mismatch error, got success")
-            } catch LoginError.generic(let description) {
-                XCTAssertTrue(description.starts(with: "State mismatch"))
+            } catch LoginError.clientError {
+                XCTAssertTrue(true)
             } catch {
                 XCTFail("Expected state mismatch error, got \(error)")
             }
@@ -53,6 +53,144 @@ extension AppAuthSessionTests {
         waitForTruth(self.sut.isActive, timeout: 10)
         
         try sut.finalise(redirectURL: URL(string: "https://www.google.com?code=\(UUID().uuidString)&state=\(UUID().uuidString)")!)
+        
+        wait(for: [exp], timeout: 2)
+    }
+    
+    @MainActor
+    func test_authService_rejectsUserCancelled() throws {
+        let exp = expectation(description: "Wait for token response")
+        Task {
+            do {
+                _ = try await sut.performLoginFlow(configuration: .mock, service: MockOIDAuthState_UserCancelled.self)
+                XCTFail("Expected user cancelled error, got success")
+            } catch LoginError.userCancelled {
+                XCTAssertTrue(true)
+            } catch {
+                XCTFail("Expected user cancelled error, got \(error)")
+            }
+            
+            exp.fulfill()
+        }
+        
+        waitForTruth(self.sut.isActive, timeout: 2)
+        
+        try sut.finalise(redirectURL: URL(string: "https://www.google.com")!)
+
+        wait(for: [exp], timeout: 2)
+    }
+    
+    @MainActor
+    func test_authService_rejectsNetworkError() throws {
+        let exp = expectation(description: "Wait for token response")
+        Task {
+            do {
+                _ = try await sut.performLoginFlow(configuration: .mock, service: MockOIDAuthState_NetworkError.self)
+                XCTFail("Expected network error, got success")
+            } catch LoginError.network {
+                XCTAssertTrue(true)
+            } catch {
+                XCTFail("Expected network error, got \(error)")
+            }
+            
+            exp.fulfill()
+        }
+        
+        waitForTruth(self.sut.isActive, timeout: 2)
+        
+        try sut.finalise(redirectURL: URL(string: "https://www.google.com")!)
+        
+        wait(for: [exp], timeout: 2)
+    }
+    
+    @MainActor
+    func test_authService_rejectsNon200() throws {
+        let exp = expectation(description: "Wait for token response")
+        Task {
+            do {
+                _ = try await sut.performLoginFlow(configuration: .mock, service: MockOIDAuthState_Non200.self)
+                XCTFail("Expected non 200 error, got success")
+            } catch LoginError.non200 {
+                XCTAssertTrue(true)
+            } catch {
+                XCTFail("Expected non 200 error, got \(error)")
+            }
+            
+            exp.fulfill()
+        }
+        
+        waitForTruth(self.sut.isActive, timeout: 2)
+        
+        try sut.finalise(redirectURL: URL(string: "https://www.google.com")!)
+        
+        wait(for: [exp], timeout: 2)
+    }
+    
+    @MainActor
+    func test_authService_rejectsAuthorizationInvalidRequest() throws {
+        let exp = expectation(description: "Wait for token response")
+        Task {
+            do {
+                _ = try await sut.performLoginFlow(configuration: .mock, service: MockOIDAuthState_AuthorizationInvalidRequest.self)
+                XCTFail("Expected authorization invalid request error, got success")
+            } catch LoginError.invalidRequest {
+                XCTAssertTrue(true)
+            } catch {
+                XCTFail("Expected authorization invalid request error, got \(error)")
+            }
+            
+            exp.fulfill()
+        }
+        
+        waitForTruth(self.sut.isActive, timeout: 2)
+        
+        try sut.finalise(redirectURL: URL(string: "https://www.google.com")!)
+        
+        wait(for: [exp], timeout: 2)
+    }
+    
+    @MainActor
+    func test_authService_rejectsClientError() throws {
+        let exp = expectation(description: "Wait for token response")
+        Task {
+            do {
+                _ = try await sut.performLoginFlow(configuration: .mock, service: MockOIDAuthState_ClientError.self)
+                XCTFail("Expected client error, got success")
+            } catch LoginError.clientError {
+                XCTAssertTrue(true)
+            } catch {
+                XCTFail("Expected client error, got \(error)")
+            }
+            
+            exp.fulfill()
+        }
+        
+        waitForTruth(self.sut.isActive, timeout: 2)
+        
+        try sut.finalise(redirectURL: URL(string: "https://www.google.com")!)
+        
+        wait(for: [exp], timeout: 2)
+    }
+    
+    @MainActor
+    func test_authService_rejectsTokenInvalidRequest() throws {
+        let exp = expectation(description: "Wait for token response")
+        Task {
+            do {
+                _ = try await sut.performLoginFlow(configuration: .mock, service: MockOIDAuthState_TokenInvalidRequest.self)
+                XCTFail("Expected token invalid request error, got success")
+            } catch LoginError.invalidRequest {
+                XCTAssertTrue(true)
+            } catch {
+                XCTFail("Expected token invalid request error, got \(error)")
+            }
+            
+            exp.fulfill()
+        }
+        
+        waitForTruth(self.sut.isActive, timeout: 2)
+        
+        try sut.finalise(redirectURL: URL(string: "https://www.google.com")!)
         
         wait(for: [exp], timeout: 2)
     }

--- a/Tests/AuthenticationTests/Mocks/AuthorizationInvalidRequest/MockOIDAuthState_AuthorizationInvalidRequest.swift
+++ b/Tests/AuthenticationTests/Mocks/AuthorizationInvalidRequest/MockOIDAuthState_AuthorizationInvalidRequest.swift
@@ -1,0 +1,15 @@
+import AppAuthCore
+import UIKit
+
+public class MockOIDAuthState_AuthorizationInvalidRequest: OIDAuthState {
+    public override class func authState(
+        byPresenting authorizationRequest: OIDAuthorizationRequest,
+        presenting presentingViewController: UIViewController,
+        prefersEphemeralSession: Bool,
+        callback: @escaping OIDAuthStateAuthorizationCallback
+    ) -> OIDExternalUserAgentSession {
+        let session = MockOIDExternalUserAgentSession_AuthorizationInvalidRequest()
+        session.callback = callback
+        return session
+    }
+}

--- a/Tests/AuthenticationTests/Mocks/AuthorizationInvalidRequest/MockOIDExternalUserAgentSession_AuthorizationInvalidRequest.swift
+++ b/Tests/AuthenticationTests/Mocks/AuthorizationInvalidRequest/MockOIDExternalUserAgentSession_AuthorizationInvalidRequest.swift
@@ -1,7 +1,9 @@
 import AppAuthCore
 
+// swiftlint:disable type_name
 public class MockOIDExternalUserAgentSession_AuthorizationInvalidRequest: NSObject,
                                                                           OIDExternalUserAgentSession {
+// swiftlint:enable type_name
     var callback: OIDAuthStateAuthorizationCallback?
     
     public func cancel() { }

--- a/Tests/AuthenticationTests/Mocks/AuthorizationInvalidRequest/MockOIDExternalUserAgentSession_AuthorizationInvalidRequest.swift
+++ b/Tests/AuthenticationTests/Mocks/AuthorizationInvalidRequest/MockOIDExternalUserAgentSession_AuthorizationInvalidRequest.swift
@@ -1,0 +1,19 @@
+import AppAuthCore
+
+public class MockOIDExternalUserAgentSession_AuthorizationInvalidRequest: NSObject,
+                                                                          OIDExternalUserAgentSession {
+    var callback: OIDAuthStateAuthorizationCallback?
+    
+    public func cancel() { }
+    
+    public func cancel() async { }
+    
+    public func failExternalUserAgentFlowWithError(_ error: Error) { }
+    
+    public func resumeExternalUserAgentFlow(with URL: URL) -> Bool {
+        let authState: OIDAuthState? = nil
+        let error: Error? = NSError(domain: OIDOAuthAuthorizationErrorDomain, code: -2)
+        callback?(authState, error)
+        return true
+    }
+}

--- a/Tests/AuthenticationTests/Mocks/ClientError/MockOIDAuthState_ClientError.swift
+++ b/Tests/AuthenticationTests/Mocks/ClientError/MockOIDAuthState_ClientError.swift
@@ -1,0 +1,15 @@
+import AppAuthCore
+import UIKit
+
+public class MockOIDAuthState_ClientError: OIDAuthState {
+    public override class func authState(
+        byPresenting authorizationRequest: OIDAuthorizationRequest,
+        presenting presentingViewController: UIViewController,
+        prefersEphemeralSession: Bool,
+        callback: @escaping OIDAuthStateAuthorizationCallback
+    ) -> OIDExternalUserAgentSession {
+        let session = MockOIDExternalUserAgentSession_ClientError()
+        session.callback = callback
+        return session
+    }
+}

--- a/Tests/AuthenticationTests/Mocks/ClientError/MockOIDExternalUserAgentSession_ClientError.swift
+++ b/Tests/AuthenticationTests/Mocks/ClientError/MockOIDExternalUserAgentSession_ClientError.swift
@@ -1,0 +1,19 @@
+import AppAuthCore
+
+public class MockOIDExternalUserAgentSession_ClientError: NSObject,
+                                                          OIDExternalUserAgentSession {
+    var callback: OIDAuthStateAuthorizationCallback?
+    
+    public func cancel() { }
+    
+    public func cancel() async { }
+    
+    public func failExternalUserAgentFlowWithError(_ error: Error) { }
+    
+    public func resumeExternalUserAgentFlow(with URL: URL) -> Bool {
+        let authState: OIDAuthState? = nil
+        let error: Error? = NSError(domain: OIDOAuthAuthorizationErrorDomain, code: -61439)
+        callback?(authState, error)
+        return true
+    }
+}

--- a/Tests/AuthenticationTests/Mocks/MissingAuthStateProperty/MockOIDExternalUserAgentSession_MissingAuthStateProperty.swift
+++ b/Tests/AuthenticationTests/Mocks/MissingAuthStateProperty/MockOIDExternalUserAgentSession_MissingAuthStateProperty.swift
@@ -4,7 +4,6 @@ import AppAuthCore
 public class MockOIDExternalUserAgentSession_MissingAuthStateProperty: NSObject,
                                                                        OIDExternalUserAgentSession {
 // swiftlint:enable type_name
-
     var callback: OIDAuthStateAuthorizationCallback?
     
     public func cancel() { }

--- a/Tests/AuthenticationTests/Mocks/NetworkError/MockOIDAuthState_NetworkError.swift
+++ b/Tests/AuthenticationTests/Mocks/NetworkError/MockOIDAuthState_NetworkError.swift
@@ -1,0 +1,15 @@
+import AppAuthCore
+import UIKit
+
+public class MockOIDAuthState_NetworkError: OIDAuthState {
+    public override class func authState(
+        byPresenting authorizationRequest: OIDAuthorizationRequest,
+        presenting presentingViewController: UIViewController,
+        prefersEphemeralSession: Bool,
+        callback: @escaping OIDAuthStateAuthorizationCallback
+    ) -> OIDExternalUserAgentSession {
+        let session = MockOIDExternalUserAgentSession_NetworkError()
+        session.callback = callback
+        return session
+    }
+}

--- a/Tests/AuthenticationTests/Mocks/NetworkError/MockOIDExternalUserAgentSession_NetworkError.swift
+++ b/Tests/AuthenticationTests/Mocks/NetworkError/MockOIDExternalUserAgentSession_NetworkError.swift
@@ -1,0 +1,19 @@
+import AppAuthCore
+
+public class MockOIDExternalUserAgentSession_NetworkError: NSObject,
+                                                              OIDExternalUserAgentSession {
+    var callback: OIDAuthStateAuthorizationCallback?
+    
+    public func cancel() { }
+    
+    public func cancel() async { }
+    
+    public func failExternalUserAgentFlowWithError(_ error: Error) { }
+    
+    public func resumeExternalUserAgentFlow(with URL: URL) -> Bool {
+        let authState: OIDAuthState? = nil
+        let error: Error? = NSError(domain: OIDGeneralErrorDomain, code: -5)
+        callback?(authState, error)
+        return true
+    }
+}

--- a/Tests/AuthenticationTests/Mocks/Non200/MockOIDAuthState_Non200.swift
+++ b/Tests/AuthenticationTests/Mocks/Non200/MockOIDAuthState_Non200.swift
@@ -1,0 +1,15 @@
+import AppAuthCore
+import UIKit
+
+public class MockOIDAuthState_Non200: OIDAuthState {
+    public override class func authState(
+        byPresenting authorizationRequest: OIDAuthorizationRequest,
+        presenting presentingViewController: UIViewController,
+        prefersEphemeralSession: Bool,
+        callback: @escaping OIDAuthStateAuthorizationCallback
+    ) -> OIDExternalUserAgentSession {
+        let session = MockOIDExternalUserAgentSession_Non200()
+        session.callback = callback
+        return session
+    }
+}

--- a/Tests/AuthenticationTests/Mocks/Non200/MockOIDExternalUserAgentSession_Non200.swift
+++ b/Tests/AuthenticationTests/Mocks/Non200/MockOIDExternalUserAgentSession_Non200.swift
@@ -1,0 +1,19 @@
+import AppAuthCore
+
+public class MockOIDExternalUserAgentSession_Non200: NSObject,
+                                                     OIDExternalUserAgentSession {
+    var callback: OIDAuthStateAuthorizationCallback?
+    
+    public func cancel() { }
+    
+    public func cancel() async { }
+    
+    public func failExternalUserAgentFlowWithError(_ error: Error) { }
+    
+    public func resumeExternalUserAgentFlow(with URL: URL) -> Bool {
+        let authState: OIDAuthState? = nil
+        let error: Error? = NSError(domain: OIDGeneralErrorDomain, code: -6)
+        callback?(authState, error)
+        return true
+    }
+}

--- a/Tests/AuthenticationTests/Mocks/TokenInvalidRequest/MockOIDAuthState_TokenInvalidRequest.swift
+++ b/Tests/AuthenticationTests/Mocks/TokenInvalidRequest/MockOIDAuthState_TokenInvalidRequest.swift
@@ -8,7 +8,7 @@ public class MockOIDAuthState_TokenInvalidRequest: OIDAuthState {
         prefersEphemeralSession: Bool,
         callback: @escaping OIDAuthStateAuthorizationCallback
     ) -> OIDExternalUserAgentSession {
-        let session = MockOIDExternalUserAgentSession_AuthorizationInvalidRequest()
+        let session = MockOIDExternalUserAgentSession_TokenInvalidRequest()
         session.callback = callback
         return session
     }

--- a/Tests/AuthenticationTests/Mocks/TokenInvalidRequest/MockOIDAuthState_TokenInvalidRequest.swift
+++ b/Tests/AuthenticationTests/Mocks/TokenInvalidRequest/MockOIDAuthState_TokenInvalidRequest.swift
@@ -1,0 +1,15 @@
+import AppAuthCore
+import UIKit
+
+public class MockOIDAuthState_TokenInvalidRequest: OIDAuthState {
+    public override class func authState(
+        byPresenting authorizationRequest: OIDAuthorizationRequest,
+        presenting presentingViewController: UIViewController,
+        prefersEphemeralSession: Bool,
+        callback: @escaping OIDAuthStateAuthorizationCallback
+    ) -> OIDExternalUserAgentSession {
+        let session = MockOIDExternalUserAgentSession_AuthorizationInvalidRequest()
+        session.callback = callback
+        return session
+    }
+}

--- a/Tests/AuthenticationTests/Mocks/TokenInvalidRequest/MockOIDExternalUserAgentSession_TokenInvalidRequest.swift
+++ b/Tests/AuthenticationTests/Mocks/TokenInvalidRequest/MockOIDExternalUserAgentSession_TokenInvalidRequest.swift
@@ -1,7 +1,9 @@
 import AppAuthCore
 
+// swiftlint:disable type_name
 public class MockOIDExternalUserAgentSession_TokenInvalidRequest: NSObject,
                                                                   OIDExternalUserAgentSession {
+// swiftlint:enable type_name
     var callback: OIDAuthStateAuthorizationCallback?
     
     public func cancel() { }

--- a/Tests/AuthenticationTests/Mocks/TokenInvalidRequest/MockOIDExternalUserAgentSession_TokenInvalidRequest.swift
+++ b/Tests/AuthenticationTests/Mocks/TokenInvalidRequest/MockOIDExternalUserAgentSession_TokenInvalidRequest.swift
@@ -1,0 +1,19 @@
+import AppAuthCore
+
+public class MockOIDExternalUserAgentSession_TokenInvalidRequest: NSObject,
+                                                                  OIDExternalUserAgentSession {
+    var callback: OIDAuthStateAuthorizationCallback?
+    
+    public func cancel() { }
+    
+    public func cancel() async { }
+    
+    public func failExternalUserAgentFlowWithError(_ error: Error) { }
+    
+    public func resumeExternalUserAgentFlow(with URL: URL) -> Bool {
+        let authState: OIDAuthState? = nil
+        let error: Error? = NSError(domain: OIDOAuthTokenErrorDomain, code: -2)
+        callback?(authState, error)
+        return true
+    }
+}

--- a/Tests/AuthenticationTests/Mocks/UserCancelled/MockOIDAuthState_UserCancelled.swift
+++ b/Tests/AuthenticationTests/Mocks/UserCancelled/MockOIDAuthState_UserCancelled.swift
@@ -1,0 +1,15 @@
+import AppAuthCore
+import UIKit
+
+public class MockOIDAuthState_UserCancelled: OIDAuthState {
+    public override class func authState(
+        byPresenting authorizationRequest: OIDAuthorizationRequest,
+        presenting presentingViewController: UIViewController,
+        prefersEphemeralSession: Bool,
+        callback: @escaping OIDAuthStateAuthorizationCallback
+    ) -> OIDExternalUserAgentSession {
+        let session = MockOIDExternalUserAgentSession_UserCancelled()
+        session.callback = callback
+        return session
+    }
+}

--- a/Tests/AuthenticationTests/Mocks/UserCancelled/MockOIDExternalUserAgentSession_UserCancelled.swift
+++ b/Tests/AuthenticationTests/Mocks/UserCancelled/MockOIDExternalUserAgentSession_UserCancelled.swift
@@ -1,0 +1,19 @@
+import AppAuthCore
+
+public class MockOIDExternalUserAgentSession_UserCancelled: NSObject,
+                                                            OIDExternalUserAgentSession {
+    var callback: OIDAuthStateAuthorizationCallback?
+    
+    public func cancel() { }
+    
+    public func cancel() async { }
+    
+    public func failExternalUserAgentFlowWithError(_ error: Error) { }
+    
+    public func resumeExternalUserAgentFlow(with URL: URL) -> Bool {
+        let authState: OIDAuthState? = nil
+        let error: Error? = NSError(domain: OIDGeneralErrorDomain, code: -3)
+        callback?(authState, error)
+        return true
+    }
+}


### PR DESCRIPTION
# feat: transform AppAuth errors

Previously we have been throwing a `LoginError.generic(description: String)` error for any error received back from the openID AppAuth package. This PR transforms those openID errors into errors owned by the package.

# Checklist

## Before raising your pull request:
~- [ ] Update the documentation to reflect your changes~
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    ~- [ ] Checked dynamic type sizes are applied~
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
- [x] Targeted the correct branch; `develop`, `release` or `main`
