### PR TITLE
feat: adding custom case to Scope enum

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/Authentication/LoginSessionConfiguration.swift
+++ b/Sources/Authentication/LoginSessionConfiguration.swift
@@ -19,11 +19,27 @@ public struct LoginSessionConfiguration {
         case code
     }
     
-    public enum Scope: String, CaseIterable {
+    public enum Scope: Equatable {
         case openid
         case email
         case phone
         case offline_access
+        case custom(String)
+        
+        var rawValue: String {
+            switch self {
+            case .openid:
+                "openid"
+            case .email:
+                "email"
+            case .phone:
+                "phone"
+            case .offline_access:
+                "offline_access"
+            case .custom(let scope):
+                scope
+            }
+        }
     }
     
     public enum UILocale: String {


### PR DESCRIPTION
# DCMAW-7460: iOS | STS | App calls Auth via STS when feature flag is enabled

We intend the app to work with Secure Token Service (STS). Which will be a One Login service that will provide delegated access control to internal One Login resources. This PR adds a `custom` value to the `Scopes` enum with an associated string value within `LoginSessionConfiguration` to allow for the call to the STS `/authorize` endpoint.

# Checklist

## Before raising your pull request:
~- [ ] Update the documentation to reflect your changes~
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
~- [ ] Written Unit and Integration tests if needed~

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [x] Targeted the correct branch; `develop`, `release` or `main`
