### PR TITLE
ci: Update GitHub workflows actions to use commit shas 

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]
     branches: [ main ]
-    
-concurrency: 
+
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
@@ -20,11 +20,11 @@ jobs:
         run: echo "/usr/local/bin" >> $GITHUB_PATH
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
         with:
           lfs: 'true'
           fetch-depth: 0
-          
+
       - name: Run Linter
         run: |
           brew install swiftlint
@@ -35,7 +35,7 @@ jobs:
         uses: Oliver-Binns/Versioning@3fe853c28bce81e7cfdedf3967734b785c256181 # 1.0.0
         with:
           ACTION_TYPE: 'Validate'
-          
+
       - name: Xcode select
         run: |
           sudo xcode-select -s /Applications/Xcode_15.2.app
@@ -52,9 +52,9 @@ jobs:
           bash xccov-to-sonarqube-generic.sh result.xcresult > sonarqube-generic-coverage.xml
           
           brew install sonar-scanner
-          
+
           pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-          
+
           sonar-scanner \
             -Dsonar.token=$SONAR_TOKEN \
             -Dsonar.coverageReportPaths="sonarqube-generic-coverage.xml" \
@@ -64,11 +64,10 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
+
       - name: Check SonarCloud Results
-        uses: sonarsource/sonarqube-quality-gate-action@master
+        uses: sonarsource/sonarqube-quality-gate-action@72f24ebf1f81eda168a979ce14b8203273b7c3ad # pin@master
         # Force to fail step after specific time
         timeout-minutes: 5
         env:
-         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Validate Pull Request Name
         id: versioning
-        uses: Oliver-Binns/Versioning@3fe853c28bce81e7cfdedf3967734b785c256181 # 1.0.0
+        uses: Oliver-Binns/Versioning@3fe853c28bce81e7cfdedf3967734b785c256181 # pin@v1.0.0
         with:
           ACTION_TYPE: 'Validate'
 
@@ -66,7 +66,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check SonarCloud Results
-        uses: sonarsource/sonarqube-quality-gate-action@72f24ebf1f81eda168a979ce14b8203273b7c3ad # pin@master
+        uses: sonarsource/sonarqube-quality-gate-action@d304d050d930b02a896b0f85935344f023928496 # pin@v1.1.0
         # Force to fail step after specific time
         timeout-minutes: 5
         env:

--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -27,7 +27,7 @@ jobs:
           sudo xcode-select -s /Applications/Xcode_15.2.app
 
       - name: Build and Test
-        run: |+
+        run: |
           xcodebuild -scheme Authentication-Package test \
            -destination "platform=macOS,variant=Mac Catalyst" \
            -enableCodeCoverage YES \
@@ -47,7 +47,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Increment Version
         id: versioning
-        uses: Oliver-Binns/Versioning@3fe853c28bce81e7cfdedf3967734b785c256181 # 1.0.0
+        uses: Oliver-Binns/Versioning@3fe853c28bce81e7cfdedf3967734b785c256181 # pin@v1.0.0
         with:
           ACTION_TYPE: 'Release'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -5,28 +5,29 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+
 jobs:
   build:
     name: Run Quality Report
     runs-on: macos-14
     permissions:
       contents: write
-    
+
     steps:
       - name: Add path globally
         run: echo "/usr/local/bin" >> $GITHUB_PATH
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
         with:
           lfs: 'true'
-          
+
       - name: Xcode select
         run: |
           sudo xcode-select -s /Applications/Xcode_15.2.app
-          
+
       - name: Build and Test
-        run: |
+        run: |+
           xcodebuild -scheme Authentication-Package test \
            -destination "platform=macOS,variant=Mac Catalyst" \
            -enableCodeCoverage YES \
@@ -35,16 +36,15 @@ jobs:
       - name: Run SonarCloud Scanning
         run: |
           bash xccov-to-sonarqube-generic.sh result.xcresult > sonarqube-generic-coverage.xml
-          
+
           brew install sonar-scanner
-          
+
           sonar-scanner \
             -Dsonar.token=$SONAR_TOKEN \
             -Dsonar.coverageReportPaths="sonarqube-generic-coverage.xml"
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
       - name: Increment Version
         id: versioning
         uses: Oliver-Binns/Versioning@3fe853c28bce81e7cfdedf3967734b785c256181 # 1.0.0


### PR DESCRIPTION
# Update GitHub Workflow Actions

Update GitHub Workflow Actions to use commit shas instead of versions to improve security.
`pin-github-action` script has also carried out linting.

[DCMAW-8673](https://govukverify.atlassian.net/jira/software/c/projects/DCMAW/boards/440?quickFilter=1326&selectedIssue=DCMAW-8673)

# Checklist

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.



[DCMAW-8673]: https://govukverify.atlassian.net/browse/DCMAW-8673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ