### PR TITLE
fix: making idToken optional

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,7 +20,7 @@ jobs:
         run: echo "/usr/local/bin" >> $GITHUB_PATH
 
       - name: Checkout
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # pin@v4
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # pin@v4
         with:
           lfs: 'true'
           fetch-depth: 0

--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -18,9 +18,10 @@ jobs:
         run: echo "/usr/local/bin" >> $GITHUB_PATH
 
       - name: Checkout
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # pin@v4
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # pin@v4
         with:
           lfs: 'true'
+          fetch-depth: 0
 
       - name: Xcode select
         run: |

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/govuk-one-login/mobile-ios-networking.git",
       "state" : {
-        "revision" : "cc911207347074bbd0d277440124a4864c5c5d79",
-        "version" : "2.2.0"
+          "revision" : "0fecae72b5da81fe839760bce699b11a0aa46bcd",
+          "version" : "2.2.1"
       }
     }
   ],

--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -123,14 +123,13 @@ public final class AppAuthSession: LoginSession {
     
     private func generateTokenResponse(token: OIDTokenResponse, authState: OIDAuthState) throws -> TokenResponse {
         guard let accessToken = token.accessToken,
-              let idToken = token.idToken,
               let tokenType = token.tokenType,
               let expiryDate = token.accessTokenExpirationDate else {
             throw LoginError.generic(description: "Missing authState property")
         }
         return TokenResponse(accessToken: accessToken,
                              refreshToken: authState.refreshToken,
-                             idToken: idToken,
+                             idToken: token.idToken,
                              tokenType: tokenType,
                              expiryDate: expiryDate)
     }

--- a/Sources/Authentication/TokenResponse.swift
+++ b/Sources/Authentication/TokenResponse.swift
@@ -4,7 +4,7 @@ import Networking
 public struct TokenResponse: Codable {
     public let accessToken: String
     public let refreshToken: String?
-    public let idToken: String
+    public let idToken: String?
     public let tokenType: String
     public let expiryDate: Date
 }


### PR DESCRIPTION
# DCMAW-8963: iOS | Mobile Platform | STS token endpoint

STS can return an optional `id_token` parameter, dependent on the authorize request including a `scope=openid` parameter.

# Checklist

## Before raising your pull request:
- [x] Update the documentation to reflect your changes
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
- [x] Targeted the correct branch; `develop`, `release` or `main`
