### PR TITLE
feat: adding optional `persistenSessionId` to LoginSessionConfiguration

### DIFF
--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -5,7 +5,6 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
-
 jobs:
   build:
     name: Run Quality Report

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Handles creating the `config` found in `LoginSession`. It requires the following
    
   let vectorsOfTrust: String
   let locale: UILocale
+  let persistentSessionID: String?
 ```
 
 The struct also contains three enums to handle the language, the response and the scopes required for sending the `OIDAuthorizationRequest` within the AppAuthSession. 
@@ -91,7 +92,7 @@ import UserDetails
 ...
 
 let session: LoginSession
-    
+
   init(session: LoginSession) {
     self.session = session
   }
@@ -105,8 +106,9 @@ let configuration = LoginSessionConfiguration(authorizationEndpoint: url,
                                               prefersEphemeralWebSession: true,
                                               redirectURI: "someRedirectURI",
                                               vectorsOfTrust: "someVectorOfTrust",
-                                              locale: .en)
-                                              
+                                              locale: .en,
+                                              persistentSessionId: nil)
+
 session.performLoginFlow(configuration: configuration)
 
 ```

--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -37,16 +37,24 @@ public final class AppAuthSession: LoginSession {
             tokenEndpoint: configuration.tokenEndpoint
         )
         
+        var additionalParams: [String: String] {
+            var baseParams = [
+                "vtr": configuration.vectorsOfTrust.description,
+                "ui_locales": configuration.locale.rawValue
+            ]
+            if let persistentSessionId = configuration.persistentSessionId {
+                baseParams["X-Session-ID"] = persistentSessionId
+            }
+            return baseParams
+        }
+        
         let request = OIDAuthorizationRequest(
             configuration: config,
             clientId: configuration.clientID,
             scopes: configuration.scopes.map(\.rawValue),
             redirectURL: URL(string: configuration.redirectURI)!,
             responseType: configuration.responseType.rawValue,
-            additionalParameters: [
-                "vtr": configuration.vectorsOfTrust.description,
-                "ui_locales": configuration.locale.rawValue
-            ]
+            additionalParameters: additionalParams
         )
         
         return try await withCheckedThrowingContinuation { continuation in

--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -37,24 +37,22 @@ public final class AppAuthSession: LoginSession {
             tokenEndpoint: configuration.tokenEndpoint
         )
         
-        var additionalParams: [String: String] {
-            var baseParams = [
-                "vtr": configuration.vectorsOfTrust.description,
-                "ui_locales": configuration.locale.rawValue
-            ]
-            if let persistentSessionId = configuration.persistentSessionId {
-                baseParams["X-Session-ID"] = persistentSessionId
-            }
-            return baseParams
-        }
-        
         let request = OIDAuthorizationRequest(
             configuration: config,
             clientId: configuration.clientID,
             scopes: configuration.scopes.map(\.rawValue),
             redirectURL: URL(string: configuration.redirectURI)!,
             responseType: configuration.responseType.rawValue,
-            additionalParameters: additionalParams
+            additionalParameters: {
+                var params = [
+                    "vtr": configuration.vectorsOfTrust.description,
+                    "ui_locales": configuration.locale.rawValue
+                ]
+                if let persistentSessionId = configuration.persistentSessionId {
+                    params["X-Session-ID"] = persistentSessionId
+                }
+                return params
+            }()
         )
         
         return try await withCheckedThrowingContinuation { continuation in

--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -49,7 +49,7 @@ public final class AppAuthSession: LoginSession {
                     "ui_locales": configuration.locale.rawValue
                 ]
                 if let persistentSessionId = configuration.persistentSessionId {
-                    params["X-Session-ID"] = persistentSessionId
+                    params["govuk_signin_session_id"] = persistentSessionId
                 }
                 return params
             }()

--- a/Sources/Authentication/LoginSessionConfiguration.swift
+++ b/Sources/Authentication/LoginSessionConfiguration.swift
@@ -14,6 +14,7 @@ public struct LoginSessionConfiguration {
     
     public let vectorsOfTrust: [String]
     public let locale: UILocale
+    public let persistentSessionId: String?
     
     public enum ResponseType: String {
         case code
@@ -55,7 +56,8 @@ public struct LoginSessionConfiguration {
                 prefersEphemeralWebSession: Bool = true,
                 redirectURI: String,
                 vectorsOfTrust: [String] = ["Cl.Cm.P0"],
-                locale: UILocale = .en) {
+                locale: UILocale = .en,
+                persistentSessionId: String? = nil) {
         self.authorizationEndpoint = authorizationEndpoint
         self.tokenEndpoint = tokenEndpoint
         self.responseType = responseType
@@ -65,5 +67,6 @@ public struct LoginSessionConfiguration {
         self.redirectURI = redirectURI
         self.vectorsOfTrust = vectorsOfTrust
         self.locale = locale
+        self.persistentSessionId = persistentSessionId
     }
 }

--- a/Tests/AuthenticationTests/LoginSessionConfigurationTests.swift
+++ b/Tests/AuthenticationTests/LoginSessionConfigurationTests.swift
@@ -16,7 +16,8 @@ final class LoginSessionConfigurationTests: XCTestCase {
                                         prefersEphemeralWebSession: true,
                                         redirectURI: "https://www.google.com/redirect",
                                         vectorsOfTrust: ["1"],
-                                        locale: .en)
+                                        locale: .en,
+                                        persistentSessionId: "123456789")
     }
     
     override func tearDown() {
@@ -63,6 +64,10 @@ extension LoginSessionConfigurationTests {
         XCTAssertEqual(sut.locale, .en)
     }
     
+    func testPersistentSessionId() {
+        XCTAssertEqual(sut.persistentSessionId, "123456789")
+    }
+    
     func testDefaultValues() {
         sut = LoginSessionConfiguration(authorizationEndpoint: URL(string: "https://www.google.com")!,
                                         tokenEndpoint: URL(string: "https://www.google.com/token")!,
@@ -73,5 +78,6 @@ extension LoginSessionConfigurationTests {
         XCTAssertTrue(sut.prefersEphemeralWebSession)
         XCTAssertEqual(sut.vectorsOfTrust, ["Cl.Cm.P0"])
         XCTAssertEqual(sut.vectorsOfTrust.description, "[\"Cl.Cm.P0\"]")
+        XCTAssertNil(sut.persistentSessionId)
     }
 }


### PR DESCRIPTION
# DCMAW-9389: iOS | Retrieve & extract persistent session ID and send in STS /authorize request

Making optionally passing a `persistenSessionId` as part of the reauth flow available.

# Checklist

## Before raising your pull request:
- [x] Update the documentation to reflect your changes
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
- [x] Targeted the correct branch; `develop`, `release` or `main`
