### PR TITLE
feat: implementing server error

### DIFF
--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -108,6 +108,8 @@ public final class AppAuthSession: LoginSession {
             throw LoginError.invalidRequest
         case (OIDOAuthAuthorizationErrorDomain, -61439):
             throw LoginError.clientError
+        case (OIDOAuthAuthorizationErrorDomain, -7):
+            throw LoginError.serverError
         default:
             throw LoginError.generic(description: error.localizedDescription)
         }

--- a/Sources/Authentication/LoginError.swift
+++ b/Sources/Authentication/LoginError.swift
@@ -5,6 +5,7 @@ public enum LoginError: Error, Equatable {
     case network
     case non200
     case userCancelled
+    case serverError
     
     public var localizedDescription: String {
         switch self {
@@ -20,6 +21,8 @@ public enum LoginError: Error, Equatable {
             return "non 200"
         case .userCancelled:
             return "user cancelled"
+        case .serverError:
+            return "server error"
         }
     }
 }

--- a/Tests/AuthenticationTests/AppAuthSessionTests.swift
+++ b/Tests/AuthenticationTests/AppAuthSessionTests.swift
@@ -263,6 +263,29 @@ extension AppAuthSessionTests {
         
         wait(for: [exp], timeout: 2)
     }
+    
+    @MainActor
+    func test_authService_rejectsWhenServerError() throws {
+        let exp = expectation(description: "Wait for token response")
+        Task {
+            do {
+                _ = try await sut.performLoginFlow(configuration: .mock, service: MockOIDAuthState_ServerError.self)
+                XCTFail("Expected missing authstate property error, got success")
+            } catch let error as LoginError {
+                XCTAssertEqual(error, .serverError)
+            } catch {
+                XCTFail("Expected missing authstate property error, got \(error)")
+            }
+            
+            exp.fulfill()
+        }
+        
+        waitForTruth(self.sut.isActive, timeout: 2)
+        
+        try sut.finalise(redirectURL: URL(string: "https://www.google.com")!)
+        
+        wait(for: [exp], timeout: 2)
+    }
 }
 
 extension LoginSessionConfiguration {

--- a/Tests/AuthenticationTests/LoginErrorTests.swift
+++ b/Tests/AuthenticationTests/LoginErrorTests.swift
@@ -19,5 +19,7 @@ extension LoginErrorTests {
         XCTAssertEqual(sut.localizedDescription, "non 200")
         sut = .userCancelled
         XCTAssertEqual(sut.localizedDescription, "user cancelled")
+        sut = .serverError
+        XCTAssertEqual(sut.localizedDescription, "server error")
     }
 }

--- a/Tests/AuthenticationTests/Mocks/ServerError/MockOIDAuthState_ServerError.swift
+++ b/Tests/AuthenticationTests/Mocks/ServerError/MockOIDAuthState_ServerError.swift
@@ -1,0 +1,15 @@
+import AppAuthCore
+import UIKit
+
+public class MockOIDAuthState_ServerError: OIDAuthState {
+    public override class func authState(
+        byPresenting authorizationRequest: OIDAuthorizationRequest,
+        presenting presentingViewController: UIViewController,
+        prefersEphemeralSession: Bool,
+        callback: @escaping OIDAuthStateAuthorizationCallback
+    ) -> OIDExternalUserAgentSession {
+        let session = MockOIDExternalUserAgentSession_ServerError()
+        session.callback = callback
+        return session
+    }
+}

--- a/Tests/AuthenticationTests/Mocks/ServerError/MockOIDExternalUserAgentSession_ServerError.swift
+++ b/Tests/AuthenticationTests/Mocks/ServerError/MockOIDExternalUserAgentSession_ServerError.swift
@@ -1,0 +1,21 @@
+import AppAuthCore
+
+// swiftlint:disable type_name
+public class MockOIDExternalUserAgentSession_ServerError: NSObject,
+                                                          OIDExternalUserAgentSession {
+// swiftlint:enable type_name
+    var callback: OIDAuthStateAuthorizationCallback?
+    
+    public func cancel() { }
+    
+    public func cancel() async { }
+    
+    public func failExternalUserAgentFlowWithError(_ error: Error) { }
+    
+    public func resumeExternalUserAgentFlow(with URL: URL) -> Bool {
+        let authState: OIDAuthState? = nil
+        let error: Error? = NSError(domain: OIDOAuthAuthorizationErrorDomain, code: -7)
+        callback?(authState, error)
+        return true
+    }
+}

--- a/Tests/AuthenticationTests/Mocks/ServerError/MockOIDExternalUserAgentSession_ServerError.swift
+++ b/Tests/AuthenticationTests/Mocks/ServerError/MockOIDExternalUserAgentSession_ServerError.swift
@@ -1,9 +1,7 @@
 import AppAuthCore
 
-// swiftlint:disable type_name
 public class MockOIDExternalUserAgentSession_ServerError: NSObject,
                                                           OIDExternalUserAgentSession {
-// swiftlint:enable type_name
     var callback: OIDAuthStateAuthorizationCallback?
     
     public func cancel() { }


### PR DESCRIPTION
# DCMAW-9216: User sees 'Unable to login' error when a server_error occurs

Adding server error as error scenario to be called in OneLogin repo

# Checklist

## Before raising your pull request:
~- [ ] Update the documentation to reflect your changes~
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
- [x] Targeted the correct branch; `develop`, `release` or `main`
