### PR TITLE
fix: computing token parameters and headers at token exchange request

### DIFF
--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -10,7 +10,7 @@ public final class AppAuthSession: LoginSession {
         userAgent != nil
     }
     
-    private var task: Task<Void, Never>? {
+    private var loginTask: Task<Void, Never>? {
         didSet {
             oldValue?.cancel()
         }
@@ -23,7 +23,7 @@ public final class AppAuthSession: LoginSession {
     }
     
     deinit {
-        task?.cancel()
+        loginTask?.cancel()
     }
     
     /// Ensures `performLoginFlow` is public and can be called by the app
@@ -57,7 +57,7 @@ public final class AppAuthSession: LoginSession {
                 presenting: viewController,
                 prefersEphemeralSession: configuration.prefersEphemeralWebSession
             ) { [unowned self] authResponse, error in
-                task = Task {
+                loginTask = Task {
                     await finaliseLoginWithAuthResponse(
                         configuration: configuration,
                         service: service,

--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -94,16 +94,16 @@ public final class AppAuthSession: LoginSession {
     func handleAuthorizationResponseCreateTokenRequest(
         _ authorizationResponse: OIDAuthorizationResponse?,
         error: Error?,
-        tokenParameters: @escaping () async -> TokenParameters?,
-        tokenHeaders: @escaping () async -> TokenHeaders?
+        tokenParameters: @escaping () async throws -> TokenParameters?,
+        tokenHeaders: @escaping () async throws -> TokenHeaders?
     ) async throws -> OIDTokenRequest {
         try handleIfError(error)
         guard let authorizationResponse else {
             throw LoginError.generic(description: "No Authorization Response")
         }
         guard let tokenRequest = authorizationResponse.tokenExchangeRequest(
-            withAdditionalParameters: await tokenParameters(),
-            additionalHeaders: await tokenHeaders()
+            withAdditionalParameters: try await tokenParameters(),
+            additionalHeaders: try await tokenHeaders()
         ) else {
             throw LoginError.generic(description: "Couldn't create Token Request")
         }

--- a/Sources/Authentication/LoginSessionConfiguration.swift
+++ b/Sources/Authentication/LoginSessionConfiguration.swift
@@ -54,18 +54,20 @@ public struct LoginSessionConfiguration {
         case cy
     }
     
-    public init(authorizationEndpoint: URL,
-                tokenEndpoint: URL,
-                responseType: ResponseType = .code,
-                scopes: [Scope] = [.openid, .email, .phone, .offline_access],
-                clientID: String,
-                prefersEphemeralWebSession: Bool = true,
-                redirectURI: String,
-                vectorsOfTrust: [String] = ["Cl.Cm.P0"],
-                locale: UILocale = .en,
-                persistentSessionId: String? = nil,
-                tokenParameters: @escaping @autoclosure () async throws -> TokenParameters? = nil,
-                tokenHeaders: @escaping @autoclosure () async throws -> TokenHeaders? = nil) async {
+    public init(
+        authorizationEndpoint: URL,
+        tokenEndpoint: URL,
+        responseType: ResponseType = .code,
+        scopes: [Scope] = [.openid, .email, .phone, .offline_access],
+        clientID: String,
+        prefersEphemeralWebSession: Bool = true,
+        redirectURI: String,
+        vectorsOfTrust: [String] = ["Cl.Cm.P0"],
+        locale: UILocale = .en,
+        persistentSessionId: String? = nil,
+        tokenParameters: @escaping @autoclosure () async throws -> TokenParameters? = nil,
+        tokenHeaders: @escaping @autoclosure () async throws -> TokenHeaders? = nil
+    ) async {
         self.authorizationEndpoint = authorizationEndpoint
         self.tokenEndpoint = tokenEndpoint
         self.responseType = responseType

--- a/Sources/Authentication/LoginSessionConfiguration.swift
+++ b/Sources/Authentication/LoginSessionConfiguration.swift
@@ -19,8 +19,8 @@ public struct LoginSessionConfiguration {
     public let vectorsOfTrust: [String]
     public let locale: UILocale
     public let persistentSessionId: String?
-    public let tokenParameters: () async -> TokenParameters?
-    public let tokenHeaders: () async -> TokenHeaders?
+    public let tokenParameters: () async throws -> TokenParameters?
+    public let tokenHeaders: () async throws -> TokenHeaders?
     
     public enum ResponseType: String {
         case code
@@ -64,8 +64,8 @@ public struct LoginSessionConfiguration {
                 vectorsOfTrust: [String] = ["Cl.Cm.P0"],
                 locale: UILocale = .en,
                 persistentSessionId: String? = nil,
-                tokenParameters: @escaping @autoclosure () async -> TokenParameters? = nil,
-                tokenHeaders: @escaping @autoclosure () async  -> TokenHeaders? = nil) async {
+                tokenParameters: @escaping @autoclosure () async throws -> TokenParameters? = nil,
+                tokenHeaders: @escaping @autoclosure () async throws -> TokenHeaders? = nil) async {
         self.authorizationEndpoint = authorizationEndpoint
         self.tokenEndpoint = tokenEndpoint
         self.responseType = responseType

--- a/Sources/Authentication/LoginSessionConfiguration.swift
+++ b/Sources/Authentication/LoginSessionConfiguration.swift
@@ -19,8 +19,8 @@ public struct LoginSessionConfiguration {
     public let vectorsOfTrust: [String]
     public let locale: UILocale
     public let persistentSessionId: String?
-    public let tokenParameters: TokenParameters?
-    public let tokenHeaders: TokenHeaders?
+    public let tokenParameters: () async -> TokenParameters?
+    public let tokenHeaders: () async -> TokenHeaders?
     
     public enum ResponseType: String {
         case code
@@ -64,8 +64,8 @@ public struct LoginSessionConfiguration {
                 vectorsOfTrust: [String] = ["Cl.Cm.P0"],
                 locale: UILocale = .en,
                 persistentSessionId: String? = nil,
-                tokenParameters: TokenParameters? = nil,
-                tokenHeaders: TokenHeaders? = nil) {
+                tokenParameters: @escaping @autoclosure () async -> TokenParameters? = nil,
+                tokenHeaders: @escaping @autoclosure () async  -> TokenHeaders? = nil) async {
         self.authorizationEndpoint = authorizationEndpoint
         self.tokenEndpoint = tokenEndpoint
         self.responseType = responseType

--- a/Tests/AuthenticationTests/AppAuthSessionAdditionalTests.swift
+++ b/Tests/AuthenticationTests/AppAuthSessionAdditionalTests.swift
@@ -6,7 +6,7 @@ extension AppAuthSessionTests {
     @MainActor
     func test_handleAuthorizationResponseCreateTokenRequest_noAuthorizationResponse() async throws {
         do {
-            _ = try await sut.handleAuthorizationResponseCreateTokenRequest(
+            _ = try await sut.handleAuthResponseCreateTokenRequest(
                 nil,
                 error: nil,
                 tokenParameters: {nil},
@@ -26,7 +26,7 @@ extension AppAuthSessionTests {
         )
 
         do {
-            let tokenRequest = try await sut.handleAuthorizationResponseCreateTokenRequest(
+            let tokenRequest = try await sut.handleAuthResponseCreateTokenRequest(
                 authorizationResponse,
                 error: nil,
                 tokenParameters: {[
@@ -55,7 +55,7 @@ extension AppAuthSessionTests {
         )
         
         do {
-            _ = try await sut.handleAuthorizationResponseCreateTokenRequest(
+            _ = try await sut.handleAuthResponseCreateTokenRequest(
                 authorizationResponse,
                 error: nil,
                 tokenParameters: {nil},

--- a/Tests/AuthenticationTests/AppAuthSessionAdditionalTests.swift
+++ b/Tests/AuthenticationTests/AppAuthSessionAdditionalTests.swift
@@ -4,13 +4,13 @@ import XCTest
 
 extension AppAuthSessionTests {
     @MainActor
-    func test_handleAuthorizationResponseCreateTokenRequest_noAuthorizationResponse() throws {
+    func test_handleAuthorizationResponseCreateTokenRequest_noAuthorizationResponse() async throws {
         do {
-            _ = try sut.handleAuthorizationResponseCreateTokenRequest(
+            _ = try await sut.handleAuthorizationResponseCreateTokenRequest(
                 nil,
                 error: nil,
-                tokenParameters: nil,
-                tokenHeaders: nil
+                tokenParameters: {nil},
+                tokenHeaders: {nil}
             )
             XCTFail("Expected no authorization response error, got success")
         } catch LoginError.generic(let description) {
@@ -19,24 +19,24 @@ extension AppAuthSessionTests {
     }
     
     @MainActor
-    func test_handleAuthorizationResponseCreateTokenRequest_addHeaders() throws {
+    func test_handleAuthorizationResponseCreateTokenRequest_addHeaders() async throws {
         let authorizationResponse = MockAuthorizationResponse_AddingHeaders(
             request: OIDAuthorizationRequest.mockAuthorizationRequest,
             parameters: .init()
         )
 
         do {
-            let tokenRequest = try sut.handleAuthorizationResponseCreateTokenRequest(
+            let tokenRequest = try await sut.handleAuthorizationResponseCreateTokenRequest(
                 authorizationResponse,
                 error: nil,
-                tokenParameters: [
+                tokenParameters: {[
                     "token_parameter_1": "test_parameter_1",
                     "token_parameter_2": "test_parameter_2"
-                ],
-                tokenHeaders: [
+                ]},
+                tokenHeaders: {[
                     "token_header_1": "test_header_1",
                     "token_header_2": "test_header_2"
-                ]
+                ]}
             )
             XCTAssertEqual(tokenRequest.additionalParameters?["token_parameter_1"], "test_parameter_1")
             XCTAssertEqual(tokenRequest.additionalParameters?["token_parameter_2"], "test_parameter_2")
@@ -48,18 +48,18 @@ extension AppAuthSessionTests {
     }
     
     @MainActor
-    func test_handleAuthorizationResponseCreateTokenRequest_noTokenResponse() throws {
+    func test_handleAuthorizationResponseCreateTokenRequest_noTokenResponse() async throws {
         let authorizationResponse = MockAuthorizationResponse_MissingTokenRequest(
             request: OIDAuthorizationRequest.mockAuthorizationRequest,
             parameters: .init()
         )
         
         do {
-            _ = try sut.handleAuthorizationResponseCreateTokenRequest(
+            _ = try await sut.handleAuthorizationResponseCreateTokenRequest(
                 authorizationResponse,
                 error: nil,
-                tokenParameters: nil,
-                tokenHeaders: nil
+                tokenParameters: {nil},
+                tokenHeaders: {nil}
             )
             XCTFail("Expected no token request error, got success")
         } catch LoginError.generic(let description) {

--- a/Tests/AuthenticationTests/AppAuthSessionTests.swift
+++ b/Tests/AuthenticationTests/AppAuthSessionTests.swift
@@ -32,7 +32,7 @@ extension AppAuthSessionTests {
         let exp = expectation(description: "Wait for token response")
         Task {
             do {
-                _ = try await sut.performLoginFlow(configuration: .mock)
+                _ = try await sut.performLoginFlow(configuration: .mock())
                 XCTFail("Expected client error, got success")
             } catch let error as LoginError {
                 XCTAssertEqual(error, .clientError)
@@ -56,7 +56,7 @@ extension AppAuthSessionTests {
         Task {
             do {
                 _ = try await sut.performLoginFlow(
-                    configuration: .mock,
+                    configuration: .mock(),
                     service: MockOIDAuthorizationService_UserCancelled.self
                 )
                 XCTFail("Expected user cancelled error, got success")
@@ -82,7 +82,7 @@ extension AppAuthSessionTests {
         Task {
             do {
                 _ = try await sut.performLoginFlow(
-                    configuration: .mock,
+                    configuration: .mock(),
                     service: MockOIDAuthorizationService_NetworkError.self
                 )
                 XCTFail("Expected network error, got success")
@@ -108,7 +108,7 @@ extension AppAuthSessionTests {
         Task {
             do {
                 _ = try await sut.performLoginFlow(
-                    configuration: .mock,
+                    configuration: .mock(),
                     service: MockOIDAuthorizationService_Non200.self
                 )
                 XCTFail("Expected non 200 error, got success")
@@ -134,7 +134,7 @@ extension AppAuthSessionTests {
         Task {
             do {
                 _ = try await sut.performLoginFlow(
-                    configuration: .mock,
+                    configuration: .mock(),
                     service: MockOIDAuthorizationService_AuthorizationInvalidRequest.self
                 )
                 XCTFail("Expected authorization invalid request error, got success")
@@ -160,7 +160,7 @@ extension AppAuthSessionTests {
         Task {
             do {
                 _ = try await sut.performLoginFlow(
-                    configuration: .mock,
+                    configuration: .mock(),
                     service: MockOIDAuthorizationService_TokenInvalidRequest.self
                 )
                 XCTFail("Expected token invalid request error, got success")
@@ -186,7 +186,7 @@ extension AppAuthSessionTests {
         Task {
             do {
                 _ = try await sut.performLoginFlow(
-                    configuration: .mock,
+                    configuration: .mock(),
                     service: MockOIDAuthorizationService_ClientError.self
                 )
                 XCTFail("Expected client error, got success")
@@ -212,7 +212,7 @@ extension AppAuthSessionTests {
         Task {
             do {
                 _ = try await sut.performLoginFlow(
-                    configuration: .mock,
+                    configuration: .mock(),
                     service: MockOIDAuthorizationService_ServerError.self
                 )
                 XCTFail("Expected server error, got success")
@@ -240,7 +240,7 @@ extension AppAuthSessionTests {
         Task {
             do {
                 _ = try await sut.performLoginFlow(
-                    configuration: .mock,
+                    configuration: .mock(),
                     service: MockOIDAuthorizationService_Perform_ClientError.self
                 )
                 XCTFail("Expected client error, got success")
@@ -266,7 +266,7 @@ extension AppAuthSessionTests {
         Task {
             do {
                 let tokens = try await sut.performLoginFlow(
-                    configuration: .mock,
+                    configuration: .mock(),
                     service: MockOIDAuthorizationService_Perform_Flow.self
                 )
                 XCTAssertEqual(tokens.accessToken, "1234567890")
@@ -304,10 +304,14 @@ extension AppAuthSessionTests {
 }
 
 extension LoginSessionConfiguration {
-    static let mock = LoginSessionConfiguration(
-        authorizationEndpoint: URL(string: "https://www.google.com")!,
-        tokenEndpoint: URL(string: "https://www.google.com/token")!,
-        clientID: "1234",
-        redirectURI: "https://www.google.com"
-    )
+    static let mock = {
+        await LoginSessionConfiguration(
+            authorizationEndpoint: URL(
+                string: "https://www.google.com"
+            )!,
+            tokenEndpoint: URL(string: "https://www.google.com/token")!,
+            clientID: "1234",
+            redirectURI: "https://www.google.com"
+        )
+    }
 }

--- a/Tests/AuthenticationTests/LoginSessionConfigurationTests.swift
+++ b/Tests/AuthenticationTests/LoginSessionConfigurationTests.swift
@@ -5,19 +5,19 @@ final class LoginSessionConfigurationTests: XCTestCase {
     
     var sut: LoginSessionConfiguration!
     
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         
-        sut = LoginSessionConfiguration(authorizationEndpoint: URL(string: "https://www.google.com/authorize")!,
-                                        tokenEndpoint: URL(string: "https://www.google.com/token")!,
-                                        responseType: .code,
-                                        scopes: [.email],
-                                        clientID: "1234",
-                                        prefersEphemeralWebSession: true,
-                                        redirectURI: "https://www.google.com/redirect",
-                                        vectorsOfTrust: ["1"],
-                                        locale: .en,
-                                        persistentSessionId: "123456789")
+        sut = await LoginSessionConfiguration(authorizationEndpoint: URL(string: "https://www.google.com/authorize")!,
+                                              tokenEndpoint: URL(string: "https://www.google.com/token")!,
+                                              responseType: .code,
+                                              scopes: [.email],
+                                              clientID: "1234",
+                                              prefersEphemeralWebSession: true,
+                                              redirectURI: "https://www.google.com/redirect",
+                                              vectorsOfTrust: ["1"],
+                                              locale: .en,
+                                              persistentSessionId: "123456789")
     }
     
     override func tearDown() {
@@ -68,11 +68,11 @@ extension LoginSessionConfigurationTests {
         XCTAssertEqual(sut.persistentSessionId, "123456789")
     }
     
-    func test_defaultValues() {
-        sut = LoginSessionConfiguration(authorizationEndpoint: URL(string: "https://www.google.com")!,
-                                        tokenEndpoint: URL(string: "https://www.google.com/token")!,
-                                        clientID: "1234",
-                                        redirectURI: "https://www.google.com/redirect")
+    func test_defaultValues() async {
+        sut = await LoginSessionConfiguration(authorizationEndpoint: URL(string: "https://www.google.com")!,
+                                              tokenEndpoint: URL(string: "https://www.google.com/token")!,
+                                              clientID: "1234",
+                                              redirectURI: "https://www.google.com/redirect")
         XCTAssertEqual(sut.responseType, .code)
         XCTAssertEqual(sut.scopes, [.openid, .email, .phone, .offline_access])
         XCTAssertTrue(sut.prefersEphemeralWebSession)


### PR DESCRIPTION
# fix: computing token parameters and headers at token exchange request

Previously, token parameters and headers were passed as variables at the start of the flow.
For use in an asynchronous context this is not suitable, as these should be computed at the point of generating the token request. 

# Checklist

## Before raising your pull request:
~- [ ] Update the documentation to reflect your changes~
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
- [x] Targeted the correct branch; `develop`, `release` or `main`
