### PR TITLE
feat: transform access_denied error

### DIFF
--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -167,6 +167,7 @@ public final class AppAuthSession: LoginSession {
         case (OIDOAuthAuthorizationErrorDomain, -7):
             throw LoginError.serverError
         default:
+            print("AUTHENTICATION ERROR", error)
             throw LoginError.generic(description: error.localizedDescription)
         }
     }

--- a/Sources/Authentication/AppAuthSession.swift
+++ b/Sources/Authentication/AppAuthSession.swift
@@ -166,8 +166,9 @@ public final class AppAuthSession: LoginSession {
             throw LoginError.clientError
         case (OIDOAuthAuthorizationErrorDomain, -7):
             throw LoginError.serverError
+        case (OIDOAuthAuthorizationErrorDomain, -4):
+            throw LoginError.accessDenied
         default:
-            print("AUTHENTICATION ERROR", error)
             throw LoginError.generic(description: error.localizedDescription)
         }
     }

--- a/Sources/Authentication/LoginError.swift
+++ b/Sources/Authentication/LoginError.swift
@@ -6,6 +6,7 @@ public enum LoginError: Error, Equatable {
     case non200
     case userCancelled
     case serverError
+    case accessDenied
     
     public var localizedDescription: String {
         switch self {
@@ -23,6 +24,8 @@ public enum LoginError: Error, Equatable {
             return "user cancelled"
         case .serverError:
             return "server error"
+        case .accessDenied:
+            return "access denied"
         }
     }
 }

--- a/Tests/AuthenticationTests/LoginErrorTests.swift
+++ b/Tests/AuthenticationTests/LoginErrorTests.swift
@@ -21,5 +21,7 @@ extension LoginErrorTests {
         XCTAssertEqual(sut.localizedDescription, "user cancelled")
         sut = .serverError
         XCTAssertEqual(sut.localizedDescription, "server error")
+        sut = .accessDenied
+        XCTAssertEqual(sut.localizedDescription, "access denied")
     }
 }

--- a/Tests/AuthenticationTests/Mocks/PresentErrors/AccessDenied/MockOIDAuthorizationService_AccessDenied.swift
+++ b/Tests/AuthenticationTests/Mocks/PresentErrors/AccessDenied/MockOIDAuthorizationService_AccessDenied.swift
@@ -1,0 +1,15 @@
+import AppAuthCore
+import UIKit
+
+class MockOIDAuthorizationService_AccessDenied: OIDAuthorizationService {
+    public override class func present(
+        _ request: OIDAuthorizationRequest,
+        presenting presentingViewController: UIViewController,
+        prefersEphemeralSession: Bool,
+        callback: @escaping OIDAuthorizationCallback
+    ) -> any OIDExternalUserAgentSession {
+        let session = MockOIDExternalUserAgentSession_AccessDenied()
+        session.callback = callback
+        return session
+    }
+}

--- a/Tests/AuthenticationTests/Mocks/PresentErrors/AccessDenied/MockOIDExternalUserAgentSession_AccessDenied.swift
+++ b/Tests/AuthenticationTests/Mocks/PresentErrors/AccessDenied/MockOIDExternalUserAgentSession_AccessDenied.swift
@@ -1,8 +1,7 @@
 import AppAuthCore
 
-// swiftlint:disable:next type_name
-class MockOIDExternalUserAgentSession_AuthorizationInvalidRequest: NSObject,
-                                                                   OIDExternalUserAgentSession {
+class MockOIDExternalUserAgentSession_AccessDenied: NSObject,
+                                                    OIDExternalUserAgentSession {
     var callback: OIDAuthorizationCallback?
     
     public func cancel() { }
@@ -14,7 +13,7 @@ class MockOIDExternalUserAgentSession_AuthorizationInvalidRequest: NSObject,
     public func resumeExternalUserAgentFlow(with URL: URL) -> Bool {
         let error: Error? = NSError(
             domain: OIDOAuthAuthorizationErrorDomain,
-            code: -2
+            code: -4
         )
         callback?(nil, error)
         return true

--- a/Tests/AuthenticationTests/Mocks/PresentErrors/ClientError/MockOIDExternalUserAgentSession_ClientError.swift
+++ b/Tests/AuthenticationTests/Mocks/PresentErrors/ClientError/MockOIDExternalUserAgentSession_ClientError.swift
@@ -1,7 +1,7 @@
 import AppAuthCore
 
 class MockOIDExternalUserAgentSession_ClientError: NSObject,
-                                                         OIDExternalUserAgentSession {
+                                                   OIDExternalUserAgentSession {
     var callback: OIDAuthorizationCallback?
     
     public func cancel() { }

--- a/Tests/AuthenticationTests/Mocks/PresentErrors/NetworkError/MockOIDExternalUserAgentSession_NetworkError.swift
+++ b/Tests/AuthenticationTests/Mocks/PresentErrors/NetworkError/MockOIDExternalUserAgentSession_NetworkError.swift
@@ -1,7 +1,7 @@
 import AppAuthCore
 
 class MockOIDExternalUserAgentSession_NetworkError: NSObject,
-                                                          OIDExternalUserAgentSession {
+                                                    OIDExternalUserAgentSession {
     var callback: OIDAuthorizationCallback?
     
     public func cancel() { }

--- a/Tests/AuthenticationTests/Mocks/PresentErrors/Non200/MockOIDExternalUserAgentSession_Non200.swift
+++ b/Tests/AuthenticationTests/Mocks/PresentErrors/Non200/MockOIDExternalUserAgentSession_Non200.swift
@@ -1,7 +1,7 @@
 import AppAuthCore
 
 class MockOIDExternalUserAgentSession_Non200: NSObject,
-                                                    OIDExternalUserAgentSession {
+                                              OIDExternalUserAgentSession {
     var callback: OIDAuthorizationCallback?
     
     public func cancel() { }

--- a/Tests/AuthenticationTests/Mocks/PresentErrors/ServerError/MockOIDExternalUserAgentSession_ServerError.swift
+++ b/Tests/AuthenticationTests/Mocks/PresentErrors/ServerError/MockOIDExternalUserAgentSession_ServerError.swift
@@ -1,7 +1,7 @@
 import AppAuthCore
 
 class MockOIDExternalUserAgentSession_ServerError: NSObject,
-                                                         OIDExternalUserAgentSession {
+                                                   OIDExternalUserAgentSession {
     var callback: OIDAuthorizationCallback?
     
     public func cancel() { }

--- a/Tests/AuthenticationTests/Mocks/PresentErrors/TokenInvalidRequest/MockOIDExternalUserAgentSession_TokenInvalidRequest.swift
+++ b/Tests/AuthenticationTests/Mocks/PresentErrors/TokenInvalidRequest/MockOIDExternalUserAgentSession_TokenInvalidRequest.swift
@@ -2,7 +2,7 @@ import AppAuthCore
 
 // swiftlint:disable:next type_name
 class MockOIDExternalUserAgentSession_TokenInvalidRequest: NSObject,
-                                                                  OIDExternalUserAgentSession {
+                                                           OIDExternalUserAgentSession {
     var callback: OIDAuthorizationCallback?
     
     public func cancel() { }

--- a/Tests/AuthenticationTests/Mocks/PresentErrors/UserCancelled/MockOIDExternalUserAgentSession_UserCancelled.swift
+++ b/Tests/AuthenticationTests/Mocks/PresentErrors/UserCancelled/MockOIDExternalUserAgentSession_UserCancelled.swift
@@ -1,7 +1,7 @@
 import AppAuthCore
 
 class MockOIDExternalUserAgentSession_UserCancelled: NSObject,
-                                                            OIDExternalUserAgentSession {
+                                                     OIDExternalUserAgentSession {
     var callback: OIDAuthorizationCallback?
     
     public func cancel() { }


### PR DESCRIPTION
# feat: transform access_denied error

An `access_denied` error needs to be handled specifically. This PR transforms a AppAuth [`OIDErrorCodeOAuthAccessDenied`](https://github.com/openid/AppAuth-iOS/blob/master/Sources/AppAuthCore/OIDError.h#L178-L181) into a `LoginError.accessDenied` error.

# Checklist

## Before raising your pull request:
~- [ ] Update the documentation to reflect your changes~
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
- [x] Targeted the correct branch; `develop`, `release` or `main`
