### PR TITLE
feat: DCMAW-18568 added test coverage for id token

### DIFF
--- a/Tests/AuthenticationTests/AppAuthSession/AppAuthSessionTestsGeneralErrors.swift
+++ b/Tests/AuthenticationTests/AppAuthSession/AppAuthSessionTestsGeneralErrors.swift
@@ -29,15 +29,15 @@ extension AppAuthSessionTests {
     // MARK: A suite of tests on ID token verification
     // A Suite of tests that assert the validity of an ID token in the format expected to be issued by STS.
     
-    //  GIVEN an ID token
-    //  AND the iss claim equals https://token.account.gov.uk
-    //  AND the aud claim equals bYrcuRVvnylvEgYSSbBjwXzHrwJ
-    //  WHEN performing a login
-    //  AND the request matches the issuer
-    //  AND the request matches the audience
-    //  ASSERT that no (validation) error occured
     @MainActor
     func test_loginFlow_succeeds_validation() throws {
+        //  GIVEN an ID token
+        //  AND the iss claim equals https://token.account.gov.uk
+        //  AND the aud claim equals bYrcuRVvnylvEgYSSbBjwXzHrwJ
+        //  WHEN performing a login
+        //  AND the request matches the issuer
+        //  AND the request matches the audience
+        //  ASSERT that no (validation) error occured
         let exp = expectation(description: #function)
         
         // Given a token
@@ -78,15 +78,15 @@ extension AppAuthSessionTests {
         XCTAssertNil(caughtError)
     }
     
-    //  GIVEN an ID token
-    //  AND the iss claim equals https://token.account.gov.uk
-    //  AND the aud claim equals bYrcuRVvnylvEgYSSbBjwXzHrwJ
-    //  WHEN performing a login
-    //  AND the request DOES NOT match the issuer
-    //  AND the request matches the audience
-    //  ASSERT that a login error occured for the issuer mismatch
     @MainActor
     func test_loginFlow_fails_validation_issuer_mismatch() throws {
+        //  GIVEN an ID token
+        //  AND the iss claim equals https://token.account.gov.uk
+        //  AND the aud claim equals bYrcuRVvnylvEgYSSbBjwXzHrwJ
+        //  WHEN performing a login
+        //  AND the request DOES NOT match the issuer
+        //  AND the request matches the audience
+        //  ASSERT that a login error occured for the issuer mismatch
         let exp = expectation(description: #function)
 
         // Given a token
@@ -130,15 +130,15 @@ extension AppAuthSessionTests {
         XCTAssertEqual(le?.underlyingReason, "Issuer mismatch")
     }
 
-    //  GIVEN an ID token
-    //  AND the iss claim equals https://token.account.gov.uk
-    //  AND the aud claim equals bYrcuRVvnylvEgYSSbBjwXzHrwJ
-    //  WHEN performing a login
-    //  AND the request matches the issuer
-    //  AND the request DOES NOT match the audience
-    //  ASSERT that a login error occured for the audience mismatch
     @MainActor
     func test_loginFlow_fails_validation_audience_mismatch() throws {
+        //  GIVEN an ID token
+        //  AND the iss claim equals https://token.account.gov.uk
+        //  AND the aud claim equals bYrcuRVvnylvEgYSSbBjwXzHrwJ
+        //  WHEN performing a login
+        //  AND the request matches the issuer
+        //  AND the request DOES NOT match the audience
+        //  ASSERT that a login error occured for the audience mismatch
         let exp = expectation(description: #function)
 
         // Given a token
@@ -182,16 +182,16 @@ extension AppAuthSessionTests {
         XCTAssertEqual(le?.underlyingReason, "Audience mismatch")
     }
     
-    //  GIVEN an ID token
-    //  AND the iss claim equals https://token.account.gov.uk
-    //  AND the aud claim equals bYrcuRVvnylvEgYSSbBjwXzHrwJ
-    //  AND the token has long EXPIRED
-    //  WHEN performing a login
-    //  AND the request matches the issuer
-    //  AND the request matches the audience
-    //  ASSERT that a login error occured for the expired id token
     @MainActor
     func test_loginFlow_fails_validation_token_expired() throws {
+        //  GIVEN an ID token
+        //  AND the iss claim equals https://token.account.gov.uk
+        //  AND the aud claim equals bYrcuRVvnylvEgYSSbBjwXzHrwJ
+        //  AND the token has long EXPIRED
+        //  WHEN performing a login
+        //  AND the request matches the issuer
+        //  AND the request matches the audience
+        //  ASSERT that a login error occured for the expired id token
         let exp = expectation(description: #function)
 
         // Given an EXPIRED token

--- a/Tests/AuthenticationTests/AppAuthSession/AppAuthSessionTestsGeneralErrors.swift
+++ b/Tests/AuthenticationTests/AppAuthSession/AppAuthSessionTestsGeneralErrors.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 @testable import Authentication
 import XCTest
 
@@ -24,6 +25,217 @@ final class AppAuthSessionTests: XCTestCase {
 }
 
 extension AppAuthSessionTests {
+    
+    // MARK: A suite of tests on ID token verification
+    // A Suite of tests that assert the validity of an ID token in the format expected to be issued by STS.
+    
+    //  GIVEN an ID token
+    //  AND the iss claim equals https://token.account.gov.uk
+    //  AND the aud claim equals bYrcuRVvnylvEgYSSbBjwXzHrwJ
+    //  WHEN performing a login
+    //  AND the request matches the issuer
+    //  AND the request matches the audience
+    //  ASSERT that no (validation) error occured
+    @MainActor
+    func test_loginFlow_succeeds_validation() throws {
+        let exp = expectation(description: #function)
+        
+        // Given a token
+        let audience = "bYrcuRVvnylvEgYSSbBjwXzHrwJ"
+        let issuer = "https://token.account.gov.uk"
+
+        let unique = UUID().uuidString
+        let endPoint = URL(string: "https://token.account.gov.uk/token?u=\(unique)")!
+
+        let claims = try Claims.make(audience: audience, issuer: issuer)
+        try MockTokenURLProtocol.token(endPoint: endPoint, stub: claims)
+
+        let service = PartialMockOIDAuthorizationServiceAllowsPerformTokenRequest.mock()
+        service.stub(endPoint: endPoint, session: .mock(authorizationResponse: .mock(mockTokenRequest: .mock(endPoint: endPoint, issuer: URL(string: issuer), audience: audience))))
+
+        // When
+        var caughtError: Error?
+
+        Task {
+            do {
+                let tokens = try await self.sut.performLoginFlow(
+                    configuration: .stub(tokenEndPoint: endPoint, issuer: URL(string: issuer), audience: audience),
+                    service: service)
+                XCTAssertNotNil(tokens)
+            } catch {
+                caughtError = error
+            }
+            
+            exp.fulfill()
+        }
+        
+        waitForTruth(self.sut.isActive, timeout: 10)
+        try sut.finalise(redirectURL: redirectURL)
+
+        wait(for: [exp], timeout: 5)
+
+        // Then
+        XCTAssertNil(caughtError)
+    }
+    
+    //  GIVEN an ID token
+    //  AND the iss claim equals https://token.account.gov.uk
+    //  AND the aud claim equals bYrcuRVvnylvEgYSSbBjwXzHrwJ
+    //  WHEN performing a login
+    //  AND the request DOES NOT match the issuer
+    //  AND the request matches the audience
+    //  ASSERT that a login error occured for the issuer mismatch
+    @MainActor
+    func test_loginFlow_fails_validation_issuer_mismatch() throws {
+        let exp = expectation(description: #function)
+
+        // Given a token
+        let audience = "bYrcuRVvnylvEgYSSbBjwXzHrwJ"
+        let issuer = "https://token.account.gov.uk"
+
+        let unique = UUID().uuidString
+        let endPoint = URL(string: "https://token.account.gov.uk/token?u=\(unique)")!
+
+        let claims = try Claims.make(audience: audience, issuer: issuer)
+        try MockTokenURLProtocol.token(endPoint: endPoint, stub: claims)
+
+        let mismatchedIssuer = "https://invalid.gov.uk"
+        let service = PartialMockOIDAuthorizationServiceAllowsPerformTokenRequest.mock()
+        service.stub(endPoint: endPoint,
+                     session: .mock(authorizationResponse: .mock(mockTokenRequest: .mock(endPoint: endPoint, issuer: URL(string: mismatchedIssuer), audience: audience))))
+
+        // When
+        var caughtError: Error?
+
+        Task {
+            do {
+                let tokens = try await self.sut.performLoginFlow(
+                    configuration: .stub(tokenEndPoint: endPoint, issuer: URL(string: mismatchedIssuer), audience: audience),
+                    service: service)
+                XCTAssertNotNil(tokens)
+            } catch {
+                caughtError = error
+            }
+            
+            exp.fulfill()
+        }
+        
+        waitForTruth(self.sut.isActive, timeout: 10)
+        try sut.finalise(redirectURL: redirectURL)
+
+        wait(for: [exp], timeout: 5)
+
+        XCTAssertNotNil(caughtError)
+        let le = caughtError as? LoginError
+        XCTAssertEqual(le?.underlyingReason, "Issuer mismatch")
+    }
+
+    //  GIVEN an ID token
+    //  AND the iss claim equals https://token.account.gov.uk
+    //  AND the aud claim equals bYrcuRVvnylvEgYSSbBjwXzHrwJ
+    //  WHEN performing a login
+    //  AND the request matches the issuer
+    //  AND the request DOES NOT match the audience
+    //  ASSERT that a login error occured for the audience mismatch
+    @MainActor
+    func test_loginFlow_fails_validation_audience_mismatch() throws {
+        let exp = expectation(description: #function)
+
+        // Given a token
+        let audience = "bYrcuRVvnylvEgYSSbBjwXzHrwJ"
+        let issuer = "https://token.account.gov.uk"
+
+        let unique = UUID().uuidString
+        let endPoint = URL(string: "https://token.account.gov.uk/token?u=\(unique)")!
+
+        let claims = try Claims.make(audience: audience, issuer: issuer)
+        try MockTokenURLProtocol.token(endPoint: endPoint, stub: claims)
+
+        let invalidAudience = "invalid aud"
+        let service = PartialMockOIDAuthorizationServiceAllowsPerformTokenRequest.mock()
+        service.stub(endPoint: endPoint,
+                     session: .mock(authorizationResponse: .mock(mockTokenRequest: .mock(endPoint: endPoint, issuer: URL(string: issuer), audience: invalidAudience))))
+
+        // When
+        var caughtError: Error?
+
+        Task {
+            do {
+                let tokens = try await self.sut.performLoginFlow(
+                    configuration: .stub(tokenEndPoint: endPoint, issuer: URL(string: issuer), audience: audience),
+                    service: service)
+                XCTAssertNotNil(tokens)
+            } catch {
+                caughtError = error
+            }
+            
+            exp.fulfill()
+        }
+        
+        waitForTruth(self.sut.isActive, timeout: 10)
+        try sut.finalise(redirectURL: redirectURL)
+
+        wait(for: [exp], timeout: 5)
+
+        XCTAssertNotNil(caughtError)
+        let le = caughtError as? LoginError
+        XCTAssertEqual(le?.underlyingReason, "Audience mismatch")
+    }
+    
+    //  GIVEN an ID token
+    //  AND the iss claim equals https://token.account.gov.uk
+    //  AND the aud claim equals bYrcuRVvnylvEgYSSbBjwXzHrwJ
+    //  AND the token has long EXPIRED
+    //  WHEN performing a login
+    //  AND the request matches the issuer
+    //  AND the request matches the audience
+    //  ASSERT that a login error occured for the expired id token
+    @MainActor
+    func test_loginFlow_fails_validation_token_expired() throws {
+        let exp = expectation(description: #function)
+
+        // Given an EXPIRED token
+        let audience = "bYrcuRVvnylvEgYSSbBjwXzHrwJ"
+        let issuer = "https://token.account.gov.uk"
+      
+        let unique = UUID().uuidString
+        let endPoint = URL(string: "https://token.account.gov.uk/token?u=\(unique)")!
+
+        let claims = try Claims.make(audience: audience, issuer: issuer, expiresAt: Date.distantPast)
+        try MockTokenURLProtocol.token(endPoint: endPoint, stub: claims)
+
+        let service = PartialMockOIDAuthorizationServiceAllowsPerformTokenRequest.mock()
+        service.stub(endPoint: endPoint,
+                     session: .mock(authorizationResponse: .mock(mockTokenRequest: .mock(endPoint: endPoint, issuer: URL(string: issuer), audience: audience))))
+        
+        // When
+        var caughtError: Error?
+
+        Task {
+            do {
+                let tokens = try await self.sut.performLoginFlow(
+                    configuration: .stub(tokenEndPoint: endPoint, issuer: URL(string: issuer), audience: audience),
+                    service: service)
+                XCTAssertNotNil(tokens)
+            } catch {
+                caughtError = error
+            }
+            
+            exp.fulfill()
+        }
+        
+        waitForTruth(self.sut.isActive, timeout: 10)
+        try sut.finalise(redirectURL: redirectURL)
+
+        wait(for: [exp], timeout: 5)
+
+        XCTAssertNotNil(caughtError)
+        let le = caughtError as? LoginError
+        XCTAssertEqual(le?.underlyingReason, "ID Token expired")
+    }
+
+    // MARK: end of suite
+
     @MainActor
     func test_loginFlow_succeeds() throws {
         let exp = expectation(description: "Wait for token response")
@@ -221,5 +433,171 @@ extension LoginSessionConfiguration {
             clientID: "1234",
             redirectURI: "https://www.google.com"
         )
+    }
+}
+
+extension LoginSessionConfiguration {
+    static func stub(tokenEndPoint: URL = URL(string: "https://token.account.gov.uk/token")!,
+                     issuer: URL? = URL(string: "https://token.account.gov.uk"), audience clientID: String = "bYrcuRVvnylvEgYSSbBjwXzHrwJ") async -> LoginSessionConfiguration {
+        await LoginSessionConfiguration(
+            authorizationEndpoint: URL(
+                string: "https://token.account.gov.uk/authorize"
+            )!,
+            tokenEndpoint: tokenEndPoint,
+            issuer: issuer,
+            clientID: clientID,
+            redirectURI: "https://mobile.account.gov.uk/redirect"
+        )
+
+    }
+}
+
+struct Claims: Codable {
+    
+  enum InvalidClaimError: Error, LocalizedError {
+      case iatRejection
+    
+    var errorDescription: String? {
+        switch self {
+        case .iatRejection:
+            return "Issued date (aka `issuedAt`) should not be more than +/- 10 minutes away from the current time"
+        }
+    }
+  }
+    
+    /// Returns a set of Claims that can be serialised to the following JSON object using default values:
+    ///
+    ///     {
+    ///         "aud": "bYrcuRVvnylvEgYSSbBjwXzHrwJ",
+    ///         "iss": "https://token.account.gov.uk",
+    ///         "sub": "c722338b-b18b-4a6c-80d8-c295e214e379",
+    ///         "persistent_id": "af835f3a-b3f1-4b50-b3db-88c185eae46b",
+    ///         "iat": [9 minutes from now],
+    ///         "exp": [9 minutes from now],
+    ///         "nonce": "ocOunJO44mNhS5dZCVB_omA0FJggLP25nM5jsDD4uz0",
+    ///         "email": "mock@email.com",
+    ///         "email_verified": true,
+    ///         "uk.gov.account.token/walletStoreId": "LpyvURud63e1LDVO0AEf7AJvXUrFlCGRfF-tl63vUe0"
+    ///     }
+    ///
+    ///
+    /// - Parameters:
+    ///   - audience: the "aud" value in the claims
+    ///   - issuer: the "iss" value in the claims
+    ///   - issuedAt: the "iss" value in the claims; it should not be more than +/- 10 minutes on the current time for a valid claim as expected by the AppAuth validation
+    ///   - expiresAt: the date in which it expires;
+    static func make(audience aud: String = "bYrcuRVvnylvEgYSSbBjwXzHrwJ",
+                     issuer iss: String = "https://token.account.gov.uk",
+                     issuedAt iat: Date? = nil,
+                     expiresAt exp: Date? = nil) throws(InvalidClaimError) -> Claims {
+        let current = Calendar.current
+        let now = Date()
+      
+        let iat = iat ?? current.date(byAdding: .init(minute: 9), to: now)!
+        let tenMinutes: TimeInterval = 10 * 60
+      
+        guard fabs(iat.timeIntervalSinceNow) < tenMinutes else {
+          throw InvalidClaimError.iatRejection
+        }
+        
+        return Claims(
+            aud: aud,
+            iss: URL(string: iss)!,
+            sub: "c722338b-b18b-4a6c-80d8-c295e214e379",
+            persistent_id: "af835f3a-b3f1-4b50-b3db-88c185eae46b",
+            iat: iat,
+            exp: exp ?? current.date(byAdding: .init(minute: 9), to: now)!,
+            nonce: "ocOunJO44mNhS5dZCVB_omA0FJggLP25nM5jsDD4uz0",
+            email: "mock@email.com",
+            email_verified: true,
+            walletStoreId: "LpyvURud63e1LDVO0AEf7AJvXUrFlCGRfF-tl63vUe0",
+        )
+    }
+
+    let aud: String
+    let iss: URL
+    let sub: String
+    let persistent_id: String
+    let iat: Date
+    let exp: Date
+    let nonce: String
+    let email: String
+    let email_verified: Bool
+    let walletStoreId: String
+    
+    enum CodingKeys: String, CodingKey {
+        case aud
+        case iss
+        case sub
+        case persistent_id
+        case iat
+        case exp
+        case nonce
+        case email
+        case email_verified
+        case walletStoreId = "uk.gov.account.token/walletStoreId"
+    }
+}
+
+struct Claim {
+    
+    static func make() -> Claim {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .custom { date, encoder in
+            var container = encoder.singleValueContainer()
+            try container.encode(Int(date.timeIntervalSince1970))
+        }
+        
+        return Claim(encoder: encoder)
+    }
+    
+    let encoder: JSONEncoder
+    
+    /// Returns a token with the following structure
+    ///
+    /// ```
+    ///    {
+    ///        "access_token": "any",
+    ///        "refresh_token": "any",
+    ///        "id_token": [JWT value],
+    ///        "token_type": "token",
+    ///        "expires_in": 180
+    ///    }
+    /// ```
+    /// Where the "id_token" has a JWT value of:
+    ///
+    /// Header:
+    /// ```
+    ///     {
+    ///       "alg": "ES256",
+    ///       "typ": "JWT",
+    ///       "kid": "16db6587-5445-45d6-a7d9-98781ebdf93d"
+    ///     }
+    /// ```
+    ///
+    /// Payload: base64 encoded `Claims` URL safe without padding
+    ///
+    /// Signature:
+    /// ```7ocBIY_vVO83eYlYpJJJuFvl_GtWqwkeYzEDiNjSfUGGatnIW5ahcoEC-tjkIxQhVjpKhmcS_HcE34836OSXrw```
+    ///
+    /// - SeeAlso: `Claims` on how to create a set of claims with provided values
+    func token(_ claims: Claims) throws -> String {
+        let payload = try encoder.encode(claims).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .trimmingCharacters(in: CharacterSet(charactersIn: "=="))
+
+        let idToken = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjE2ZGI2NTg3LTU0NDUtNDVkNi1hN2Q5LTk4NzgxZWJkZjkzZCJ9.\(payload)." +
+            "7ocBIY_vVO83eYlYpJJJuFvl_GtWqwkeYzEDiNjSfUGGatnIW5ahcoEC-tjkIxQhVjpKhmcS_HcE34836OSXrw"
+        
+        return """
+        {
+            "access_token": "any",
+            "refresh_token": "any",
+            "id_token": "\(idToken)",
+            "token_type": "token",
+            "expires_in": 180
+        }
+        """
     }
 }

--- a/Tests/AuthenticationTests/Extensions/OIDTokenRequest+Extensions.swift
+++ b/Tests/AuthenticationTests/Extensions/OIDTokenRequest+Extensions.swift
@@ -1,21 +1,20 @@
 import AppAuthCore
-
 extension OIDTokenRequest {
-    static var mockTokenRequest: OIDTokenRequest {
+    
+    static func mock(endPoint: URL = URL(string: "https://token.account.gov.uk/token")!, issuer: URL?, audience clientID: String = "") -> OIDTokenRequest {
         let serviceConfiguration = OIDServiceConfiguration(
-            authorizationEndpoint: Foundation.URL(
-                string: "https://www.google.com"
+            authorizationEndpoint: URL(
+                string: "https://token.account.gov.uk/authorize"
             )!,
-            tokenEndpoint: Foundation.URL(
-                string: "https://www.google.com"
-            )!
+            tokenEndpoint: endPoint,
+            issuer: issuer
         )
         return OIDTokenRequest(
             configuration: serviceConfiguration,
             grantType: "",
             authorizationCode: nil,
             redirectURL: nil,
-            clientID: "",
+            clientID: clientID,
             clientSecret: nil,
             scope: nil,
             refreshToken: nil,
@@ -24,4 +23,6 @@ extension OIDTokenRequest {
             additionalHeaders: nil
         )
     }
+    
+    static var mockTokenRequest: OIDTokenRequest = .mock(issuer: nil)
 }

--- a/Tests/AuthenticationTests/Mocks/Helpers/MockAuthorizationResponse.swift
+++ b/Tests/AuthenticationTests/Mocks/Helpers/MockAuthorizationResponse.swift
@@ -1,10 +1,29 @@
 import AppAuthCore
 
+extension OIDAuthorizationResponse {
+    static func mock(mockTokenRequest: OIDTokenRequest? = .mockTokenRequest) -> OIDAuthorizationResponse {
+        return MockAuthorizationResponse(tokenExchangeRequest: mockTokenRequest)
+    }
+}
+
 class MockAuthorizationResponse: OIDAuthorizationResponse {
+        
+    let tokenExchangeRequest: OIDTokenRequest?
+    
+    init(tokenExchangeRequest: OIDTokenRequest?) {
+        self.tokenExchangeRequest = tokenExchangeRequest
+        super.init(request: OIDAuthorizationRequest.mockAuthorizationRequest, parameters: [:])
+    }
+    
+    required init?(coder: NSCoder) {
+        self.tokenExchangeRequest = nil
+        super.init(coder: coder)
+    }
+    
     override func tokenExchangeRequest(
         withAdditionalParameters additionalParameters: [String: String]?,
         additionalHeaders: [String: String]?
     ) -> OIDTokenRequest? {
-        return OIDTokenRequest.mockTokenRequest
+        return tokenExchangeRequest
     }
 }

--- a/Tests/AuthenticationTests/Mocks/Helpers/MockOIDAuthorizationService_Success.swift
+++ b/Tests/AuthenticationTests/Mocks/Helpers/MockOIDAuthorizationService_Success.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable type_name
 import AppAuthCore
 import UIKit
 
@@ -26,3 +27,190 @@ class MockOIDAuthorizationService_Success: OIDAuthorizationService {
         callback(tokenResponse, nil)
     }
 }
+
+/// Use this ``OIDAuthorizationService`` to mock ``present(_:presenting:prefersEphemeralSession:callback)`` while still being able to perform a token request
+/// i.e. ``OIDTokenRequest``.
+///
+/// Using this service also allows you to provide a stubbed response, i.e. ``OIDAuthorizationResponse``, for any token request used at
+/// ``performTokenRequest:originalAuthorizationResponse:callback:``.
+///
+/// This mock ensures that any token requests used to retrieve a token will NOT hit the network. Any othere requests will not be attempted.
+///
+/// e.g.
+///     ```
+///     let audience = "bYrcuRVvnylvEgYSSbBjwXzHrwJ"
+///     let issuer = "https://token.account.gov.uk"
+///     let endPoint = URL(string: "https://token.account.gov.uk/token")!
+///
+///     let claims = try Claims.make(audience: audience, issuer: issuer)
+///     try MockTokenURLProtocol.token(endPoint: endPoint, stub: claims)
+///
+///     let service = PartialMockOIDAuthorizationServiceAllowsPerformTokenRequest.mock()
+///
+///     service.stub(endPoint: endPoint, session: .mock(authorizationResponse: .mock(mockTokenRequest: .mock(endPoint: endPoint, issuer: URL(string: issuer), audience: audience))))
+///
+///     service.present(
+///         configuration.authorizationRequest,
+///         presenting: viewController,
+///         prefersEphemeralSession: configuration.prefersEphemeralWebSession) { authResponse, error in
+///             let tokenRequest = authorizationResponse.tokenExchangeRequest()
+///             service.perform(tokenRequest, originalAuthorizationResponse: authResponse) { tokenResponse, error in
+///             }
+///         }
+///     ```
+///
+/// - SeeAlso: ``mock(session:)`` to create a new ``PartialMockOIDAuthorizationServiceAllowsPerformTokenRequest`` mock
+/// - SeeAlso: ``MockTokenURLProtocol`` on how to stub a token for a token request
+class PartialMockOIDAuthorizationServiceAllowsPerformTokenRequest: OIDAuthorizationService {
+
+    /// Creates a new partial mock that can be used to perform token requests.
+    ///
+    /// Once you have created a mock, use ``stub(endPoint:session:)`` to provide a stub session prior to performing a token request.
+    ///
+    /// - parameter session: the session to return in ``present(_:presenting:prefersEphemeralSession:callback)``
+    static func mock() -> PartialMockOIDAuthorizationServiceAllowsPerformTokenRequest.Type {
+        
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockTokenURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        OIDURLSessionProvider.setSession(session)
+        
+        return PartialMockOIDAuthorizationServiceAllowsPerformTokenRequest.self
+    }
+    
+    ///
+    /// - Parameters
+    ///   - endPoint: the URL of the token end point for which you will be making a token request at.
+    ///   - sesssion: a succesful user agent session to be returned by ``present(_:presenting:prefersEphemeralSession:callback)``
+    /// - SeeAlso: ``OIDExternalUserAgentSession/mock(authorizationResponse:)`` on how to create a mock agent session
+    public static func stub(endPoint url: URL, session: MockOIDExternalUserAgentSession_Success) {
+        Self.stubSessions[url] = (session)
+    }
+    
+    private static var stubSessions: [URL: MockOIDExternalUserAgentSession_Success] = [:]
+    
+    public override class func present(
+        _ request: OIDAuthorizationRequest,
+        presenting presentingViewController: UIViewController,
+        prefersEphemeralSession: Bool,
+        callback: @escaping OIDAuthorizationCallback
+    ) -> any OIDExternalUserAgentSession {
+        guard let session = Self.stubSessions[request.configuration.tokenEndpoint] else {
+            return MockOIDExternalUserAgentSession_Success()
+        }
+        
+        session.callback = callback
+        return session
+    }
+}
+
+/// Use this ``URLProtocol`` to provide stub tokens and handle any token request without hitting the network.
+/// Any othere requests will not be attempted by this protocol.
+///
+/// Any token request **must** must adhere to *at least* the following properties
+/// * **host:** *token.account.gov.uk*
+/// * **last path component** */path*
+///
+/// e.g. "https://token.account.gov.uk/token"
+///
+/// - SeeAlso: ``token(endPoint:stub:statusCode)`` on how to provide a stub token for a token request
+class MockTokenURLProtocol: URLProtocol {
+    
+    enum InvalidURLError: Error, LocalizedError {
+        case notTokenURL(url: URL)
+      
+      var errorDescription: String? {
+          switch self {
+          case .notTokenURL(let url):
+              return "The token URL is expected to have a host 'token.account.gov.uk' and a last path component of 'token'. " +
+                "Got a host '\(String(describing: url.host))' and a last path '\(url.lastPathComponent)' instead. Use URL(string: \"https://token.account.gov.uk/token\""
+          }
+      }
+    }
+
+    /// - Parameters:
+    ///   - endPoint: the URL of the token end point for which you will be making a token request at.
+    ///   - stub: a set of claims that you want to return in the body of the response for the given endPoint.
+    public static func token(endPoint url: URL, stub claims: Claims, statusCode: Int = 200) throws {
+        let token = try Claim.make().token(claims)
+        try stub(endPoint: url, token: token, statusCode: 200)
+    }
+    
+    /// Stubs a response for the given endPoint
+    /// Calling this function with the same url, will replace any previous token for that url.
+    ///
+    /// Should you wish to add mutliple stubs for a token request, you can differentiate betwen each token request by adding a query to each one that
+    /// is expected to provide a different token.
+    ///
+    /// e.g.
+    ///     https://token.account.gov.uk/token?u=1
+    ///     https://token.account.gov.uk/token?u=2
+    ///
+    /// Where "u" stands for "unique" and the value is unique across the set of token requests.
+    ///
+    /// - Parameters:
+    ///   - endPoint: the URL of the token end point for which you will be making a token request at.
+    ///   - token: an id token in the format of
+    ///   ```
+    ///    {
+    ///        "access_token": [any],
+    ///        "refresh_token": [any],
+    ///        "id_token": [JWT value],
+    ///        "token_type": "token",
+    ///        "expires_in": 180
+    ///    }
+    ///    ```
+    /// - SeeAlso: ``token(endPoint:stub:statusCode:)`` on how to add a stub using a set of claims
+    /// - SeeAlso: ``Claim.make().token()`` on how to make a token in the expected format
+    public static func stub(endPoint url: URL, token json: String, statusCode: Int) throws {
+        guard isTokenURL(url) else {
+            throw InvalidURLError.notTokenURL(url: url)
+        }
+        
+        guard let data = json.data(using: .utf8),
+              let response = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)
+        else { return }
+        
+        mockResponses[url] = (data, response)
+    }
+
+    private static var mockResponses: [URL: (Data, HTTPURLResponse)] = [:]
+    
+    private class func isTokenURL(_ url: URL) -> Bool {
+        return url.host == "token.account.gov.uk" && url.lastPathComponent == "token"
+    }
+    override class func canInit(with task: URLSessionTask) -> Bool {
+        guard let url = task.originalRequest?.url else {
+            return false
+        }
+        return self.isTokenURL(url)
+    }
+    
+    override class func canInit(with request: URLRequest) -> Bool {
+        guard let url = request.url else {
+            return false
+        }
+        return self.isTokenURL(url)
+    }
+    
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+        
+    override func startLoading() {
+        guard let url = request.url else {
+            client?.urlProtocolDidFinishLoading(self)
+            return
+        }
+        
+        if let (data, response) = Self.mockResponses[url] {
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        }
+    }
+    
+    override func stopLoading() {
+    }
+}
+// swiftlint:enable type_name

--- a/Tests/AuthenticationTests/Mocks/Helpers/MockOIDExternalUserAgentSession_Success.swift
+++ b/Tests/AuthenticationTests/Mocks/Helpers/MockOIDExternalUserAgentSession_Success.swift
@@ -1,8 +1,21 @@
 import AppAuthCore
 
+extension OIDExternalUserAgentSession {
+    
+    static func mock(authorizationResponse: OIDAuthorizationResponse = .mock()) -> MockOIDExternalUserAgentSession_Success {
+        return MockOIDExternalUserAgentSession_Success(authorizationResponse: authorizationResponse)
+    }
+}
+
 class MockOIDExternalUserAgentSession_Success: NSObject,
                                                OIDExternalUserAgentSession {
+    
+    var authorizationResponse: OIDAuthorizationResponse?
     var callback: OIDAuthorizationCallback?
+
+    init(authorizationResponse: OIDAuthorizationResponse? = .mock()) {
+        self.authorizationResponse = authorizationResponse
+    }
     
     public func cancel() { }
     
@@ -11,12 +24,7 @@ class MockOIDExternalUserAgentSession_Success: NSObject,
     public func failExternalUserAgentFlowWithError(_ error: Error) { }
     
     public func resumeExternalUserAgentFlow(with URL: URL) -> Bool {
-        let authorizationResponse = MockAuthorizationResponse(
-            request: OIDAuthorizationRequest.mockAuthorizationRequest,
-            parameters: .init()
-        )
-        
-        callback?(authorizationResponse, nil)
+        callback?(self.authorizationResponse, nil)
         return true
     }
 }


### PR DESCRIPTION
# [DCMAW-18568](https://govukverify.atlassian.net/browse/DCMAW-18568) Expands test coverage for both a valid and invalid claim

This PR does not include any code changes in the source code of the Authentication package. It merely expands on the test coverage. Specifically, it adds 4 new test cases on the login flow:

* Assert a successful login flow in case of a valid claim
* Assert a login error in case of an issuer mismatch between the token request and the claim expected to be returned by STS
* Assert a login error in case of an audience mismatch between the token request and the claim expected to be returned by STS
* Assert a login error in case of an expired claim as expected to be returned by STS
* 
<img width="521" height="93" alt="Screenshot 2026-03-06 at 18 29 51" src="https://github.com/user-attachments/assets/028d93f0-67b5-4f90-a47a-26ba0e1bce29" />

## Code changes

This PR introduces a couple of classes in support of testing the above scenarios. Specifically:
* A partial mock of `OIDAuthorizationService` (`PartialMockOIDAuthorizationServiceAllowsPerformTokenRequest`) that allows a test to perform a token request and return a stub claim.
* A custom `URLProtocol` that is used by the `OIDAuthorizationService` mock to ensure that token requests do not hit the network and provide stub responses
* A `Claims` data type to create a set of claims when "issuing" a new id token. The data type also enforces constraints on the validity of a claim as expected by the `AppAuth` library, e.g. that the issued at date is -/+ 10 minutes from now.
* A `Claim` type to encode a JWT token in a format as expected to be returned by STS
* Various mocks for the types used by `AppAuth` in order to aid with testing

## Considerations

As part of working on this, I had to make special considerations:

* Eliminate or where not possible, reduce side effects and interference with other tests while `OIDAuthorizationService` is under test.  By default, the `OIDAuthorizationService` uses a shared URLSession (see `OIDURLSessionProvider`). The mock uses an ephemeral session which also allows scoping of the `MockTokenURLProtocol` to handle only requests sent to the mock.
* Constrain the `MockTokenURLProtocol` to only accept and process token requests.
* Ensure the mock of the `OIDAuthorizationService` can be used by in parallel by multiple tests. The `OIDAuthorizationService` is expected to be used as a class type (rather than an instance) when performing token requests. That means that the `OIDAuthorizationService` needs to be able to handle multiple token requests  as tests run in parallel. Both for correctness and performance considerations.

## Where to focus your review

* Correct usage of the Authentication package and by extension the AppAuth package.
* Correctness of mocks for the AppAuth package.
* Correctness and understanding of the documentation.
* Potential bugs and/or issues with the tests in terms of correctness, flakiness.

## Further discussion

I noticed that the `AppAuthSession` throws a `LoginError` with a `.generic` reason and also does not capture the underlying error (domain: `OIDGeneralErrorDomain`, code: `OIDErrorCodeIDTokenFailedValidationError`) as thrown by `AppAuth`. We might want to remedy that in the future.

# Checklist

## Before raising your pull request:
- [x] Update the documentation to reflect your changes
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`


[DCMAW-18568]: https://govukverify.atlassian.net/browse/DCMAW-18568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ