### PR TITLE
feat: DCMAW-18770 mitigate risk of script injection

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -59,11 +59,13 @@ jobs:
             -Dsonar.token=$SONAR_TOKEN \
             -Dsonar.coverageReportPaths="sonarqube-generic-coverage.xml" \
             -Dsonar.pullrequest.key=$pull_number \
-            -Dsonar.pullrequest.branch=${{github.head_ref}} \
-            -Dsonar.pullrequest.base=${{github.base_ref}}
+            -Dsonar.pullrequest.branch="${GITHUB_HEAD_REF}" \
+            -Dsonar.pullrequest.base="${GITHUB_BASE_REF}"
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
 
       - name: Check SonarCloud Results
         uses: sonarsource/sonarqube-quality-gate-action@cf038b0e0cdecfa9e56c198bbb7d21d751d62c3b # pin@v1.2.0


### PR DESCRIPTION
# [Mitigate the risk of a script injection by using an intermediate environment variable](https://govukverify.atlassian.net/browse/DCMAW-18770)

The current GitHub workflow uses a [github context variable ](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context) to evaluate the the `head_ref` or _source branch_ of the pull request and the `base_ref` or _target branch_ of the pull request in a workflow run. 

<img width="732" height="217" alt="Screenshot 2026-03-19 at 09 07 05" src="https://github.com/user-attachments/assets/72074795-742e-4702-b50e-cf60d5761b9a" />


This allows for the following attack:
* A malicious actor creates a PR where the name of the **source name of the branch** is a valid shell command. e.g. `$(echo "INJECTED")`
* The GitHub workflow runs
* The `github.head_ref`, which holds the value of `$(echo "INJECTED")` is injected into the yaml and inlined on the **script**
* At the time the workflow (i.e. script) runs, the shell has to evaluate the result of the command (i.e. `$(echo "INJECTED")`) as part of executing.

**This allows a malicious actor to execute arbitrary code in the target runner that run the workflow**.

## Changes

GitHub lists some [good practices for mitigating script injection attacks](https://docs.github.com/en/actions/reference/security/secure-use#good-practices-for-mitigating-script-injection-attacks).

> For inline scripts, the preferred approach to handling untrusted input is to set the value of the expression to an intermediate environment variable. - [Use an intermediate environment variable](https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable)

The solution for mitigating the script attack is by defining an environment variable which interprets the `github.head_ref` as a `String`, which is then used verbatim in the inline script.

## How these changes where tested

The [open source project act ](https://github.com/nektos/act) allows you to execute a workflow locally. I [created a sample git project with a workflow](https://github.com/qnoid/github-actions) that "mirrors" how the `pull-request.yml` workflow is written and demonstrates the scenario of a script injection. 

**Note:** I used the [inputs context](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#inputs-context), instead of the github context, to hold the malicious script but the result _should_ effectively be the same.

The project contains 2 commits. The [first one](https://github.com/qnoid/github-actions/commit/5fc36db0d7d9fb3a4e5015980bd3659438ba8f1d), demonstrates the script injection in practice.

<img width="1800" height="1130" alt="compromised" src="https://github.com/user-attachments/assets/b621f38a-dc89-43f0-a632-834e80363155" />

The [second one](https://github.com/qnoid/github-actions/commit/34ad369dc3dacd3a8a7343333e623efa97a0057e), uses an environment variable as recommended by GitHub to mitigate the risk

<img width="1800" height="1130" alt="secure" src="https://github.com/user-attachments/assets/d6a2347b-7ed5-424a-8652-8f12f0491d4d" />

## Where to focus the review
* Are the security risk, explanation and solution sound?
* Does the sample project **mirror** the `pull-request.yml` workflow?
* Do the changes in the `pull-request.yml` workflow mitigate the risk as described?

## Related reading
* [The Hidden Danger in Git Ref Names](https://www.kenmuse.com/blog/the-hidden-danger-in-git-ref-names/)
* Act  [Installation](https://nektosact.com/installation/gh.html) and [Usage Guide](https://nektosact.com/usage/index.html)

# Checklist

## Before raising your pull request:
- [x] Update the documentation to reflect your changes
- [ ] Ran the app locally ensuring it builds 
- [ ] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
- [ ] Targeted the correct branch; `develop`, `release` or `main`
