### PR TITLE
ci: update xcode and simulator versions to 26.5

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           set -o pipefail && xcodebuild -scheme Authentication test \
             -skipPackagePluginValidation \
-            -destination "platform=iOS Simulator,name=iPhone 17,aarch=arm64,OS=26.5" \
+            -destination "platform=iOS Simulator,name=iPhone 17,arch=arm64,OS=26.5" \
             -enableCodeCoverage YES \
             -resultBundlePath result.xcresult | xcbeautify
           

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -38,13 +38,13 @@ jobs:
 
       - name: Xcode select
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.2.app
+          sudo xcode-select -s /Applications/Xcode_26.5.app
           
       - name: Build and Test
         run: |
           set -o pipefail && xcodebuild -scheme Authentication test \
             -skipPackagePluginValidation \
-            -destination "platform=iOS Simulator,name=iPhone 17,OS=26.2" \
+            -destination "platform=iOS Simulator,name=iPhone 17,aarch=arm64,OS=26.5" \
             -enableCodeCoverage YES \
             -resultBundlePath result.xcresult | xcbeautify
           

--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           set -o pipefail && xcodebuild -scheme Authentication test \
             -skipPackagePluginValidation \
-            -destination "platform=iOS Simulator,name=iPhone 17,aarch=arm64,OS=26.5" \
+            -destination "platform=iOS Simulator,name=iPhone 17,arch=arm64,OS=26.5" \
             -enableCodeCoverage YES \
             -resultBundlePath result.xcresult | xcbeautify
             

--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -24,13 +24,13 @@ jobs:
 
       - name: Xcode select
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.1.app
+          sudo xcode-select -s /Applications/Xcode_26.5.app
 
       - name: Build and Test
         run: |
           set -o pipefail && xcodebuild -scheme Authentication test \
             -skipPackagePluginValidation \
-            -destination "platform=iOS Simulator,name=iPhone 17,OS=26.1" \
+            -destination "platform=iOS Simulator,name=iPhone 17,aarch=arm64,OS=26.5" \
             -enableCodeCoverage YES \
             -resultBundlePath result.xcresult | xcbeautify
             


### PR DESCRIPTION
# ci: update xcode and simulator versions to 26.5

Updating and making consistent the Xcode and simulator versions used for pre and post merge workflows.

# Checklist

## Before raising your pull request:
~- [ ] Update the documentation to reflect your changes~
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
~- [ ] Pull request has a clear title with ticket ID and a short description about the feature or update
      i.e. _DCMAW-222: Added ReadID SDK to iOS app_~
~- [ ] Created a `draft` pull request if it is not yet ready for review~

## Before your pull request can be reviewed:
~- [ ] Met all of the acceptance criteria specified in the user story on Jira~
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
~- [ ] Written Unit and Integration tests if needed~

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
- [x] Targeted the correct branch; `develop`, `release` or `main`
